### PR TITLE
Correcting PR link in UI

### DIFF
--- a/src/components/Environment/index.js
+++ b/src/components/Environment/index.js
@@ -17,7 +17,7 @@ const Environment = ({ environment }) => {
   const gitUrlParsed = giturlparse(environment.project.gitUrl);
   const gitBranchLink = `${gitUrlParsed.resource}/${
     gitUrlParsed.full_name
-  }/tree/${environment.name}`;
+    }/${environment.deployType === 'branch' ? `tree/${environment.name}` : `pull/${environment.name.replace(/pr-/i, '')}`}`;
 
   return (
     <div className="details">


### PR DESCRIPTION
Updated GitHub PR Link in Lagoon UI - Addresses - https://github.com/uselagoon/lagoon/issues/2040
Builds on existing PR https://github.com/uselagoon/lagoon/pull/2456

![image](https://user-images.githubusercontent.com/4373945/188524587-b40b46c5-e36c-470a-bf46-0e138685644a.png)
