### PR TITLE
Fix showing all results when selecting "all"

### DIFF
--- a/src/components/ResultsLimited/index.js
+++ b/src/components/ResultsLimited/index.js
@@ -21,10 +21,7 @@ const customStyles = {
   control: (provided) => ({
     ...provided,
     width: 200,
-  }),
-  singleValue: (provided, state) => {
-    return { ...provided, opacity, transition };
-  }
+  })
 }
 
 /**

--- a/src/components/ResultsLimited/index.js
+++ b/src/components/ResultsLimited/index.js
@@ -7,7 +7,7 @@ const options = [
   { value: '25', label: '25' },
   { value: '50', label: '50' },
   { value: '100', label: '100' },
-  { value: 'all', label: 'all' }
+  { value: '-1', label: 'all' }
 ]
 const handleChange = (values) => {
   console.log(values);


### PR DESCRIPTION
All of the pages that use the `ResultsLimited` component check for `-1` to show all results, but the component was using `all` instead.

There was also an error being thrown for every selection caused by uninstantiated variables that has been fixed.

Closes #39 