### PR TITLE
Adds case for ENVIRONMENT_SOURCE_NAME_EXCLUDE_SELF

### DIFF
--- a/src/components/AddTask/components/InvokeRegisteredTask.js
+++ b/src/components/AddTask/components/InvokeRegisteredTask.js
@@ -67,6 +67,7 @@ const InvokeRegisteredTask = ({ pageEnvironment, selectedTask, advancedTaskArgum
             switch(d.type) {
 
               case("ENVIRONMENT_SOURCE_NAME"):
+              case("ENVIRONMENT_SOURCE_NAME_EXCLUDE_SELF"):
                 return (
                   <div key={`env-text-${index}`} className="envSelect">
                     <label id="source-env">{d.displayName || d.name} :</label>


### PR DESCRIPTION
We've added a new advanced task definition argument type ENVIRONMENT_SOURCE_NAME_EXCLUDE_SELF that is currently unsupported in the UI - and defaults to simply displaying an input text box.

This fixes this issue.

closes #42 