### PR TITLE
Adds redirection and changes builds to deployments

### DIFF
--- a/server.js
+++ b/server.js
@@ -125,8 +125,20 @@ app
       });
     });
 
-    server.get('/builds', (req, res) => {
-      app.render(req, res, '/builds', {});
+    server.get('/alldeployments', (req, res) => {
+      app.render(req, res, '/alldeployments', {});
+    });
+
+
+    // Redirects for system - from https://www.raygesualdo.com/posts/301-redirects-with-nextjs
+    const redirects = [
+      { from: '/builds', to: '/alldeployments' },
+    ]
+    
+    redirects.forEach(({ from, to, type = 301, method = 'get' }) => {
+      server[method](from, (req, res) => {
+        res.redirect(type, to)
+      })
     });
 
     server.get('*', (req, res) => {

--- a/src/components/DeploymentsByFilter/index.js
+++ b/src/components/DeploymentsByFilter/index.js
@@ -85,7 +85,7 @@ const DeploymentsByFilter = ({ deployments }) => {
   return (
     <div className="deployments">
       <div className="filters">
-        <label>{sortedItems.length <= 1 ? `${sortedItems.length} Deployments` : `${sortedItems.length} Deployments`}</label>
+        <label>{sortedItems.length == 1 ? `1 deployment` : `${sortedItems.length} deployments`}</label>
         <label></label>
         <input 
           type="text" id="filter"

--- a/src/components/DeploymentsByFilter/index.js
+++ b/src/components/DeploymentsByFilter/index.js
@@ -89,7 +89,7 @@ const DeploymentsByFilter = ({ deployments }) => {
         <label></label>
         <input 
           type="text" id="filter"
-          placeholder="Filter Deployments..."
+          placeholder="Filter deployments..."
           value={searchTerm}
           onChange={handleSearchFilterChange}
         />
@@ -97,7 +97,7 @@ const DeploymentsByFilter = ({ deployments }) => {
       {!deployments.length && (
         <Box>
           <div className="data-none">
-            <h4>No Deployments</h4>
+            <h4>No deployments</h4>
           </div>
         </Box>
       )}

--- a/src/components/DeploymentsByFilter/index.js
+++ b/src/components/DeploymentsByFilter/index.js
@@ -83,13 +83,13 @@ const DeploymentsByFilter = ({ deployments }) => {
 
 
   return (
-    <div className="builds">
+    <div className="deployments">
       <div className="filters">
         <label>{sortedItems.length <= 1 ? `${sortedItems.length} Deployments` : `${sortedItems.length} Deployments`}</label>
         <label></label>
         <input 
           type="text" id="filter"
-          placeholder="Filter builds..."
+          placeholder="Filter Deployments..."
           value={searchTerm}
           onChange={handleSearchFilterChange}
         />
@@ -97,7 +97,7 @@ const DeploymentsByFilter = ({ deployments }) => {
       {!deployments.length && (
         <Box>
           <div className="data-none">
-            <h4>No deployments</h4>
+            <h4>No Deployments</h4>
           </div>
         </Box>
       )}

--- a/src/components/DeploymentsByFilter/index.js
+++ b/src/components/DeploymentsByFilter/index.js
@@ -131,7 +131,7 @@ const DeploymentsByFilter = ({ deployments }) => {
         <label></label>
       </div>
       <div className="data-table">
-        {!sortedItems.filter(deployment => filterResults(deployment)).length && <div className="data-none">No Deployments</div>}
+        {!sortedItems.filter(deployment => filterResults(deployment)).length && <div className="data-none">No deployments</div>}
         {sortedItems.filter(deployment => filterResults(deployment)).map((deployment) => {
           return (
             <div className="data-row row-heading" key={deployment.id}>

--- a/src/pages/alldeployments.js
+++ b/src/pages/alldeployments.js
@@ -17,7 +17,7 @@ import DeploymentsByFilter from '../components/DeploymentsByFilter';
 const AllDeployments = () => (
   <>
     <Head>
-      <title>All Deployments</title>
+      <title>All deployments</title>
     </Head>
     <Query query={deploymentsByFilter} displayName="deploymentsByFilter">
       {R.compose(

--- a/src/pages/alldeployments.js
+++ b/src/pages/alldeployments.js
@@ -14,10 +14,10 @@ import DeploymentsByFilter from '../components/DeploymentsByFilter';
 /**
  * Displays the projects page.
  */
-const AllBuilds = () => (
+const AllDeployments = () => (
   <>
     <Head>
-      <title>All Builds</title>
+      <title>All Deployments</title>
     </Head>
     <Query query={deploymentsByFilter} displayName="deploymentsByFilter">
       {R.compose(
@@ -25,7 +25,7 @@ const AllBuilds = () => (
       )(({ data }) => (
         <MainLayout>
           <div className="content-wrapper">
-            <h2>Builds</h2>
+            <h2>Deployments</h2>
             <div className="content">
               <DeploymentsByFilter deployments={data.deploymentsByFilter || []}/>
             </div>
@@ -58,4 +58,4 @@ const AllBuilds = () => (
   </>
 );
 
-export default withRouter(AllBuilds);
+export default withRouter(AllDeployments);


### PR DESCRIPTION
This PR renames the `allBuilds` page to `deployments` in order to have consistent terms.

It also introduces a redirect to the newly named `alldeployments` page from `builds`