### PR TITLE
Adds ability to display raw logs

### DIFF
--- a/src/components/LogViewer/index.js
+++ b/src/components/LogViewer/index.js
@@ -11,13 +11,15 @@ const withParseLogsStateHandlers = withHandlers({
   changeState: ({setParseStateChecked, checkedParseState}) => (e) => {setParseStateChecked(!checkedParseState);},
 })
 
-
 const LogViewer = ({ logs, status = "NA", checkedParseState, changeState }) => (
   <React.Fragment>
     <div className="logs">
     <div className="parseLogs"><input type="checkbox" checked={ checkedParseState } onChange={changeState}></input><span className="showraw">Parse logs</span></div>
-      {checkedParseState ? (<div className="log-viewer">{ logs !== null ? logPreprocessor(logs, status) :
-       'Logs are not available.'}</div>) : (<div className="log-viewer with-padding">{logs}</div>)}
+    { logs !== null ?
+        checkedParseState ?
+        (<div className="log-viewer">{logPreprocessor(logs, status)}</div>)
+          : (<div className="log-viewer with-padding">{logs}</div>)
+      : (<div className="log-viewer with-padding">Logs are not available.</div>) }
     </div>
     <style jsx>{`
       .logs {

--- a/src/components/LogViewer/index.js
+++ b/src/components/LogViewer/index.js
@@ -1,11 +1,23 @@
 import React, { useRef, useState } from 'react';
 import { bp } from 'lib/variables';
 import LogAccordion from 'components/LogViewer/LogAccordion';
+import withState from 'recompose/withState';
+import withHandlers from 'recompose/withHandlers';
 
-const LogViewer = ({ logs, status = "NA" }) => (
+
+const withParseLogsState = withState("checkedParseState", "setParseStateChecked", true);
+
+const withParseLogsStateHandlers = withHandlers({
+  changeState: ({setParseStateChecked, checkedParseState}) => (e) => {setParseStateChecked(!checkedParseState);},
+})
+
+
+const LogViewer = ({ logs, status = "NA", checkedParseState, changeState }) => (
   <React.Fragment>
     <div className="logs">
-      <div className="log-viewer">{ logs !== null ? logPreprocessor(logs, status) : 'Logs are not available.'}</div>
+    <div><input type="checkbox" checked={ checkedParseState } onChange={changeState}></input><span class="showraw">Parse logs</span></div>
+      {checkedParseState ? (<div className="log-viewer">{ logs !== null ? logPreprocessor(logs, status) :
+       'Logs are not available.'}</div>) : (<div className="log-viewer">{logs}</div>)}
     </div>
     <style jsx>{`
       .logs {
@@ -215,4 +227,4 @@ const logPreprocessorTokenize = (logs) => {
   return tokenizedLogs;
 }
 
-export default LogViewer;
+export default withParseLogsState(withParseLogsStateHandlers(LogViewer));

--- a/src/components/LogViewer/index.js
+++ b/src/components/LogViewer/index.js
@@ -14,7 +14,7 @@ const withParseLogsStateHandlers = withHandlers({
 const LogViewer = ({ logs, status = "NA", checkedParseState, changeState }) => (
   <React.Fragment>
     <div className="logs">
-    <div className="parseLogs"><input type="checkbox" checked={ checkedParseState } onChange={changeState}></input><span className="showraw">Parse logs</span></div>
+    <div className="parseLogs"><input type="checkbox" checked={ checkedParseState } onChange={changeState}></input><span className="showraw">Prettify logs</span></div>
     { logs !== null ?
         checkedParseState ?
         (<div className="log-viewer">{logPreprocessor(logs, status)}</div>)

--- a/src/components/LogViewer/index.js
+++ b/src/components/LogViewer/index.js
@@ -15,9 +15,9 @@ const withParseLogsStateHandlers = withHandlers({
 const LogViewer = ({ logs, status = "NA", checkedParseState, changeState }) => (
   <React.Fragment>
     <div className="logs">
-    <div><input type="checkbox" checked={ checkedParseState } onChange={changeState}></input><span class="showraw">Parse logs</span></div>
+    <div className="parseLogs"><input type="checkbox" checked={ checkedParseState } onChange={changeState}></input><span className="showraw">Parse logs</span></div>
       {checkedParseState ? (<div className="log-viewer">{ logs !== null ? logPreprocessor(logs, status) :
-       'Logs are not available.'}</div>) : (<div className="log-viewer">{logs}</div>)}
+       'Logs are not available.'}</div>) : (<div className="log-viewer with-padding">{logs}</div>)}
     </div>
     <style jsx>{`
       .logs {
@@ -36,6 +36,15 @@ const LogViewer = ({ logs, status = "NA", checkedParseState, changeState }) => (
           will-change: initial;
           word-break: break-all;
           word-wrap: break-word;
+          &.with-padding {
+            padding: 10px;
+          }
+        }
+        .parseLogs {
+          margin: 0 auto 10px;
+          .showraw {
+            margin-left: 10px;
+          }
         }
       }
     `}</style>

--- a/src/pages/deployment.js
+++ b/src/pages/deployment.js
@@ -76,17 +76,6 @@ export const PageDeployment = ({ router }) => {
           withDeploymentRequired
         )(({ data: { environment } }) => {
           const deployment = environment && environment.deployments[0];
-
-          useEffect(() => {
-            window.addEventListener("scroll", onScroll);
-
-            if (logsContent && logsContent.current.clientHeight < document.documentElement.clientHeight) {
-              setHidden("hidden");
-            }
-
-            return () => window.removeEventListener("scroll", onScroll);
-          }, [deployment]);
-
           return (
             <MainLayout>
               <div ref={logsTopRef} />
@@ -109,13 +98,6 @@ export const PageDeployment = ({ router }) => {
                 </div>
               </div>
               <div ref={logsEndRef} />
-              {/* <div className="scroll-wrapper">
-                {!hidden &&
-                  <button className={`scroll ${!showBottom ? "top" : "bottom"}`} onClick={() => !showBottom ? scrollToTop() : scrollToBottom()}>
-                    {!showBottom ? "↑" : "↓"}
-                  </button>
-                }
-              </div> */}
               <style jsx>{`
                 .content-wrapper {
                   @media ${bp.tabletUp} {


### PR DESCRIPTION
As pointed out in #65, there are times when viewing the entire log outside of the accordion is helpful.

This PR introduces a "parse logs" checkbox that when unchecked shows the logs back in the old style.

There's a persistent issue with state handing for sub-components for the page scroll logic. I've removed this - it's faulty and we need to new approach.

closes #65 