### PR TITLE
Passing in correct duration for build times on all builds page

### DIFF
--- a/src/lib/query/DeploymentsByFilter.js
+++ b/src/lib/query/DeploymentsByFilter.js
@@ -8,6 +8,8 @@ export default gql`
         status
         created
         priority
+        started
+        completed
         environment {
           name
           openshiftProjectName


### PR DESCRIPTION
This fixes the build duration being incorrect on the all builds page.