### PR TITLE
Fix: remove duplicate no deployments div

### DIFF
--- a/src/components/DeploymentsByFilter/index.js
+++ b/src/components/DeploymentsByFilter/index.js
@@ -94,13 +94,6 @@ const DeploymentsByFilter = ({ deployments }) => {
           onChange={handleSearchFilterChange}
         />
       </div>
-      {!deployments.length && (
-        <Box>
-          <div className="data-none">
-            <h4>No deployments</h4>
-          </div>
-        </Box>
-      )}
       <div className="header">
         <label>Project</label>
         <label>Environment</label>


### PR DESCRIPTION
In the `alldeployments` overview page, if there are no deployments currently available to the user, there are 2 divs displayed that show `No deployments`.

This removes one of them to make the page neater.