### PR TITLE
chore: use build setup instead of logs begin

### DIFF
--- a/src/components/LogViewer/index.js
+++ b/src/components/LogViewer/index.js
@@ -189,7 +189,7 @@ const logPreprocessorExtractSectionEndDetails = (logs) => {
 const logPreprocessorTokenize = (logs) => {
   // tokenize
   const regexp = /##############################################\n(BEGIN) (.+)\n##############################################/;
-  const beginningSectionDefaultDetails = "Logs begin";
+  const beginningSectionDefaultDetails = "Build Setup";
 
   // The regex above will split the logs into three separate token types
   // 1. standard blocks of text


### PR DESCRIPTION
Just a minor word change for the first logs accordion to `Build Setup` instead of `Logs begin`. `Logs begin` doesn't really look that appealing, and `Build Setup` fits more with what is happening from that point on.

Before:
![image](https://user-images.githubusercontent.com/9973880/213056939-24ec5918-b175-42c9-8f14-eeb8b2642455.png)

After:
![image](https://user-images.githubusercontent.com/9973880/213056968-2d05e275-eaf5-4d60-9048-5c97c7aaf308.png)
