### PR TITLE
Feature: UI changes for admin advanced tasks

### DIFF
--- a/src/components/AddTask/logic.js
+++ b/src/components/AddTask/logic.js
@@ -44,7 +44,7 @@ const withOptions = withProps(({ pageEnvironment }) => {
   ];
 
   // Add Advanced Task Definitions
-  let advancedTasks = pageEnvironment.advancedTasks.map(task => {
+  let advancedTasks = pageEnvironment.advancedTasks.filter(e => { return e.showUi == 1;}).map(task => {
     let commandstring = task.command ? `[${task.command}]` : '';
     let label = task.description ? `${task.description} ${commandstring}` :'';
     return {

--- a/src/lib/query/EnvironmentWithTasks.js
+++ b/src/lib/query/EnvironmentWithTasks.js
@@ -27,6 +27,8 @@ export default gql`
           service
           created
           deleted
+          adminTask
+          showUi
           confirmationText
           advancedTaskDefinitionArguments {
             id
@@ -46,6 +48,8 @@ export default gql`
           service
           created
           deleted
+          adminTask
+          showUi
           confirmationText
           advancedTaskDefinitionArguments {
             id


### PR DESCRIPTION
Remake of https://github.com/uselagoon/lagoon/pull/3184 to be inline with current codebase. (Requires https://github.com/uselagoon/lagoon/pull/3382 to work - tasks page will error otherwise.)

UI changes split out into this PR.

- `showUi` logic updated in the `AddTask` component
- `getEnvironment` query updated with `adminTask` & `showUi`



Note that this PR requires lagoon-core v2.12.0 to be running, otherwise tasks page will  not load