### PR TITLE
feature: add admin label to admin tasks

### DIFF
--- a/src/components/AddTask/logic.js
+++ b/src/components/AddTask/logic.js
@@ -44,7 +44,7 @@ const withOptions = withProps(({ pageEnvironment }) => {
   ];
 
   // Add Advanced Task Definitions
-  let advancedTasks = pageEnvironment.advancedTasks.filter(e => { return e.showUi == 1;}).map(task => {
+  let advancedTasks = pageEnvironment.advancedTasks.map(task => {
     let commandstring = task.command ? `[${task.command}]` : '';
     let label = task.description ? `${task.description} ${commandstring}` :'';
     return {

--- a/src/components/Tasks/index.js
+++ b/src/components/Tasks/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import moment from 'moment';
 import TaskLink from 'components/link/Task';
-import { bp, color } from 'lib/variables';
+import { bp, color, fontSize } from 'lib/variables';
 
 /**
  * Displays an environment's list of tasks.
@@ -24,7 +24,7 @@ const Tasks = ({ tasks, environmentSlug, projectSlug }) => (
           key={task.taskName}
         >
           <div className="data-row" task={task.taskName}>
-            <div className="name">{task.name}</div>
+            <div className="name">{task.name}{task.adminOnlyView && <label className="bulk-label">admin</label>}</div>
             <div className="started">
               {moment
                 .utc(task.created)
@@ -71,6 +71,19 @@ const Tasks = ({ tasks, environmentSlug, projectSlug }) => (
               width: 14%;
             }
           }
+        }
+      }
+
+      .bulk-label {
+        color: ${color.white};
+        background-color: ${color.lightBlue};
+        ${fontSize(12)};
+        margin-left: 10px;
+        padding: 0px 5px 0px 5px;
+        border-radius: 3px;
+        box-shadow: 0px 4px 8px 0px rgba(0, 0, 0, 0.03);
+        &:hover {
+          background-color: ${color.blue};
         }
       }
 

--- a/src/lib/query/EnvironmentWithTask.js
+++ b/src/lib/query/EnvironmentWithTask.js
@@ -20,6 +20,7 @@ export default gql`
         created
         service
         logs
+        adminOnlyView
         files {
           id
           filename

--- a/src/lib/query/EnvironmentWithTasks.js
+++ b/src/lib/query/EnvironmentWithTasks.js
@@ -27,8 +27,6 @@ export default gql`
           service
           created
           deleted
-          adminTask
-          showUi
           confirmationText
           advancedTaskDefinitionArguments {
             id
@@ -48,8 +46,6 @@ export default gql`
           service
           created
           deleted
-          adminTask
-          showUi
           confirmationText
           advancedTaskDefinitionArguments {
             id

--- a/src/lib/query/EnvironmentWithTasks.js
+++ b/src/lib/query/EnvironmentWithTasks.js
@@ -63,6 +63,7 @@ export default gql`
         status
         created
         service
+        adminOnlyView
       }
     }
   }


### PR DESCRIPTION
Revert showUi changes to support https://github.com/uselagoon/lagoon/pull/3393

Also add a label to tasks to identify they are admin run tasks:
![image](https://user-images.githubusercontent.com/9973880/217721499-0ec3d7b0-74e6-41ac-8885-38b5b20ca55b.png)
