### PR TITLE
Fix: Included dark mode on modal and copy components

### DIFF
--- a/src/components/ActiveStandbyConfirm/StyledActiveStandbyConfirm.tsx
+++ b/src/components/ActiveStandbyConfirm/StyledActiveStandbyConfirm.tsx
@@ -5,6 +5,12 @@ export const StyledActiveStandbyConfirm = styled.div`
   .margins {
     margin-right: 10px;
   }
+`;
+
+export const StyledActiveStandbyConfirmModal = styled.div`
+  .margins {
+    margin-right: 10px;
+  }
   input {
     margin-right: 10px;
     width: 100%;

--- a/src/components/ActiveStandbyConfirm/index.tsx
+++ b/src/components/ActiveStandbyConfirm/index.tsx
@@ -5,7 +5,7 @@ import withLogic from 'components/ActiveStandbyConfirm/logic';
 import Button from 'components/Button';
 import Modal from 'components/Modal';
 
-import { StyledActiveStandbyConfirm } from './StyledActiveStandbyConfirm';
+import { StyledActiveStandbyConfirm, StyledActiveStandbyConfirmModal } from './StyledActiveStandbyConfirm';
 
 /**
  * Confirms the deletion of the specified name and type.
@@ -33,13 +33,13 @@ export const ActiveStandbyConfirm: FC<ActiveStandbyConfirmProps> = ({
         <Button action={openModal}>Switch Active/Standby environments</Button>
       </div>
       <Modal isOpen={open} onRequestClose={closeModal} contentLabel="Confirm">
-        <React.Fragment>
+        <StyledActiveStandbyConfirmModal>
           <p>
             This will replace the current active environment
-            <span className="environment-name">{activeEnvironment}</span>
+            <span className="environment-name"> {activeEnvironment}</span>
             <br />
             with the selected standby environment
-            <span className="environment-name">{standbyEnvironment}</span>.
+            <span className="environment-name"> {standbyEnvironment}</span>.
             <br />
             <br />
             Are you sure you want to do this?
@@ -54,7 +54,7 @@ export const ActiveStandbyConfirm: FC<ActiveStandbyConfirmProps> = ({
             </a>
             <Button action={onProceed}>Confirm</Button>
           </div>
-        </React.Fragment>
+        </StyledActiveStandbyConfirmModal>
       </Modal>
     </StyledActiveStandbyConfirm>
   );

--- a/src/components/ProjectDetailsSidebar/StyledProjectSidebar.tsx
+++ b/src/components/ProjectDetailsSidebar/StyledProjectSidebar.tsx
@@ -80,9 +80,9 @@ export const FieldWrapper = styled.div`
       transform: translateX(-13px);
     }
     .field {
-      background-color: ${color.white};
+      background-color: ${props => props.theme.backgrounds.copy};
       border-right: 28px solid ${color.white};
-      color: ${color.darkGrey};
+      color: ${props => props.theme.texts.primary};
       font-family: 'source-code-pro', sans-serif;
       ${fontSize(13)};
       margin-top: 6px;
@@ -99,18 +99,17 @@ export const FieldWrapper = styled.div`
       border: none;
     }
     .copy {
-      background: url('/static/images/copy.svg') center center no-repeat ${color.white};
+      background: url('/static/images/copy.svg') center center no-repeat ${props => props.theme.backgrounds.copy};
       background-size: 16px;
-      border-left: 1px solid ${color.lightestGrey};
       bottom: 0;
-      height: 33px;
+      height: 34px;
       position: absolute;
       right: 0;
       width: 40px;
       transition: all 0.5s;
 
       &:hover {
-        background-color: ${color.midGrey};
+        background-color: ${props => props.theme.backgrounds.sidebar};
         cursor: pointer;
       }
     }

--- a/src/layouts/GlobalStyles/index.tsx
+++ b/src/layouts/GlobalStyles/index.tsx
@@ -227,7 +227,7 @@ main{
   transform: translate(-50%, -50%);
   border: 1px solid ${color.midGrey};
 
-  background: ${color.white};
+background:${(props) => props.theme.backgrounds.primary};
 
   overflow: auto;
   -webkit-overflow-scrolling: touch;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -61,7 +61,7 @@ export const lightTheme: DefaultTheme = {
     breadCrumb: color.midGrey,
     content: color.almostWhite,
     boxLabel: color.white,
-    copy: color.midGrey,
+    copy: color.white,
   },
   texts: {
     primary: color.black,


### PR DESCRIPTION
Fix for #129 & #130 - Adds the required styling to modals for dark mode + minor styling change on active standby modal content.

closes #129 #130 