### PR TITLE
Fixed styling for failed deployments in the Log Accordion

### DIFF
--- a/src/components/LogViewer/StyledLogViewer.tsx
+++ b/src/components/LogViewer/StyledLogViewer.tsx
@@ -117,7 +117,7 @@ export const StyledLogAccordion = styled.div`
       padding: 0;
     }
   }
-  .data-row.log-error-state {
+  &.data-row.log-error-state {
     .accordion-heading {
       .log-header {
         ::before {


### PR DESCRIPTION
Updated `StyledLogAccordion` to display the correct colour for failed deployments.

Closes #118 