### PR TITLE
Fix: Styles conflicts on shared components

### DIFF
--- a/src/components/AddVariable/StyledAddVariable.tsx
+++ b/src/components/AddVariable/StyledAddVariable.tsx
@@ -17,6 +17,9 @@ export const NewVariable = styled.div`
   .add-var-btn {
     margin-top: 16px;
   }
+  button.icon {
+    padding: 0 10px;
+  }
 `;
 
 export const NewVariableModal = styled.div`

--- a/src/components/DeleteVariable/StyledDeleteVariable.tsx
+++ b/src/components/DeleteVariable/StyledDeleteVariable.tsx
@@ -23,3 +23,9 @@ export const DeleteVariableModal = styled.div`
     cursor: pointer;
 }
 `;
+
+export const DeleteVariableButton = styled.div`
+  button.icon {
+    padding: 0 10px;
+  }
+`;

--- a/src/components/DeleteVariable/StyledDeleteVariable.tsx
+++ b/src/components/DeleteVariable/StyledDeleteVariable.tsx
@@ -21,7 +21,7 @@ export const DeleteVariableModal = styled.div`
   }
   .deleteConfirmImg span {
     cursor: pointer;
-}
+  }
 `;
 
 export const DeleteVariableButton = styled.div`

--- a/src/components/DeleteVariable/index.js
+++ b/src/components/DeleteVariable/index.js
@@ -4,7 +4,7 @@ import ButtonBootstrap from "react-bootstrap/Button";
 import Button from 'components/Button'
 import { Mutation } from "react-apollo";
 import withLogic from "components/AddVariable/logic";
-import {DeleteVariableModal} from "./StyledDeleteVariable";
+import {DeleteVariableModal, DeleteVariableButton} from "./StyledDeleteVariable";
 import DeleteEnvVariableMutation from "../../lib/mutation/deleteEnvVariableByName";
 
 /**
@@ -27,16 +27,18 @@ export const DeleteVariable = ({
 }) => {
   return (
       <React.Fragment>
-      {
-        icon ?
-          <Button variant='red' icon={icon} action={openModal}>
-            Delete
-          </Button>
-          :
-          <Button variant='red' action={openModal}>
-            Delete
-          </Button>
-      }
+        <DeleteVariableButton>
+          {
+            icon ?
+              <Button variant='red' icon={icon} action={openModal}>
+                Delete
+              </Button>
+              :
+              <Button variant='red' action={openModal}>
+                Delete
+              </Button>
+          }
+        </DeleteVariableButton>
       <Modal
         isOpen={open}
         onRequestClose={closeModal}

--- a/src/components/EnvironmentVariables/StyledEnvironmentVariables.tsx
+++ b/src/components/EnvironmentVariables/StyledEnvironmentVariables.tsx
@@ -1,6 +1,17 @@
 import styled from "styled-components";
 import { bp, color } from "lib/variables";
 
+export const VariableActions = styled.div`
+  display: flex;
+  gap: 10px;
+  justify-content: space-evenly;
+  > * {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+`;
+
 export const StyledEnvironmentVariableDetails = styled.div`
   padding: 32px calc((100vw / 16) * 1);
   width: 100%;
@@ -267,10 +278,20 @@ export const StyledVariableTable = styled.div`
     & .varUpdate {
         display: flex;
         padding: 0;
-        width: 10%;
+
+        button {
+          background-color: #fff;
+        }
     }
-    & .varDelete {
-      width: 10%;
+    & .varActions {
+      width: 20%;
+      display: flex;
+      align-items: center;
+
+      &:last-child {
+        justify-content: flex-end;
+        -webkit-box-pack: end;
+      }
     }
   }
 
@@ -308,8 +329,17 @@ export const StyledVariableTable = styled.div`
     & .varScope {
       width: 30%;
     }
-    & .varDelete {
+    & .varActions {
       width: 10%;
+      display: flex;
+
+      &:last-child {
+        justify-content: flex-end;
+        -webkit-box-pack: end;
+      }
+    }
+    & .varDelete {
+      padding-right: 10px;
     }
 
     &.skeleton {
@@ -500,8 +530,14 @@ export const StyledProjectVariableTable = styled.div`
     & .varName {
       padding-left: 20px;
     }
-    & .varDelete {
-      width: 5%;
+    & .varActions {
+      width: 10%;
+      display: flex;
+
+      &:last-child {
+        justify-content: flex-end;
+        -webkit-box-pack: end;
+      }
     }
 
     &.skeleton {

--- a/src/components/EnvironmentVariables/index.js
+++ b/src/components/EnvironmentVariables/index.js
@@ -13,6 +13,7 @@ import {
   StyledEnvironmentVariableDetails,
   StyledProjectVariableTable,
   StyledVariableTable,
+  VariableActions,
 } from "./StyledEnvironmentVariables";
 import Image from "next/image";
 import show from "../../static/images/show.svg";
@@ -267,35 +268,39 @@ const EnvironmentVariables = ({ environment, onVariableAdded, closeModal }) => {
                             </div>
                           </Collapse>
                         )}
-                        <Collapse in={openEnvVars}>
-                        <div className="varUpdate">
-                          <Button
-                            onClick={() => setUpdateValue(envVar.value, envVar.name, envVar.scope)}
-                            style={{ all: 'unset'}}
-                          >
-                            <AddVariable
-                                varProject={environment.project.name}
-                                varEnvironment={environment.name}
-                                varValues={displayVars}
-                                varTarget="Environment"
-                                varName={updateVarName}
-                                varValue={updateVarValue}
-                                varScope={updateVarScope}
-                                refresh={onVariableAdded}
-                                icon="edit"
-                            />
-                          </Button>
-                        </div>
-                        </Collapse>
-                        <div className="varDelete">
-                          <DeleteVariable
-                              deleteType="Environment variable"
-                              deleteName={envVar.name}
-                              varProject={environment.project.name}
-                              varEnvironment={environment.name}
-                              icon="bin"
-                              refresh={onVariableAdded}
-                          />
+                        <div className="varActions">
+                          <VariableActions>
+                            <Collapse in={openEnvVars}>
+                              <div className="varUpdate">
+                                <Button
+                                  onClick={() => setUpdateValue(envVar.value, envVar.name, envVar.scope)}
+                                  style={{ all: 'unset'}}
+                                >
+                                  <AddVariable
+                                      varProject={environment.project.name}
+                                      varEnvironment={environment.name}
+                                      varValues={displayVars}
+                                      varTarget="Environment"
+                                      varName={updateVarName}
+                                      varValue={updateVarValue}
+                                      varScope={updateVarScope}
+                                      refresh={onVariableAdded}
+                                      icon="edit"
+                                  />
+                                </Button>
+                              </div>
+                            </Collapse>
+                            <div className="varDelete">
+                              <DeleteVariable
+                                  deleteType="Environment variable"
+                                  deleteName={envVar.name}
+                                  varProject={environment.project.name}
+                                  varEnvironment={environment.name}
+                                  icon="bin"
+                                  refresh={onVariableAdded}
+                              />
+                            </div>
+                          </VariableActions>
                         </div>
                       </div>
                     </Fragment>

--- a/src/components/ProjectVariables/StyledProjectVariables.tsx
+++ b/src/components/ProjectVariables/StyledProjectVariables.tsx
@@ -1,6 +1,17 @@
 import styled from "styled-components";
 import { bp, color } from "lib/variables";
 
+export const VariableActions = styled.div`
+  display: flex;
+  gap: 10px;
+  justify-content: space-evenly;
+  > * {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+`;
+
 export const StyledProjectVariablesDetails = styled.div`
   padding: 32px calc((100vw / 16) * 1);
   width: 100%;
@@ -261,10 +272,20 @@ export const StyledProjectVariableTable = styled.div`
     & .varUpdate {
         display: flex;
         padding: 0;
-        width: 10%;
+
+        button {
+          background-color: #fff;
+        }
     }
-    & .varDelete {
-      width: 10%;
+    & .varActions {
+      width: 20%;
+      display: flex;
+      align-items: center;
+
+      &:last-child {
+        justify-content: flex-end;
+        -webkit-box-pack: end;
+      }
     }
   }
 
@@ -302,8 +323,17 @@ export const StyledProjectVariableTable = styled.div`
     & .varScope {
       width: 30%;
     }
-    & .varDelete {
+    & .varActions {
       width: 10%;
+      display: flex;
+
+      &:last-child {
+        justify-content: flex-end;
+        -webkit-box-pack: end;
+      }
+    }
+    & .varDelete {
+      padding-right: 10px;
     }
 
     &.skeleton {

--- a/src/components/ProjectVariables/index.js
+++ b/src/components/ProjectVariables/index.js
@@ -13,6 +13,7 @@ import hide from "../../static/images/hide.svg";
 import {
   StyledProjectVariablesDetails,
   StyledProjectVariableTable,
+  VariableActions,
 } from "./StyledProjectVariables";
 import DeleteVariable from "components/DeleteVariable";
 
@@ -233,33 +234,37 @@ const ProjectVariables = ({ project, onVariableAdded, closeModal }) => {
                             </div>
                           </Collapse>
                         )}
-                        <Collapse in={openPrjVars}>
-                          <div className="varUpdate">
-                            <Button
-                                onClick={() => setUpdateValue(projEnvVar.value, projEnvVar.name, projEnvVar.scope)}
-                                style={{ all: 'unset'}}
-                            >
-                              <AddVariable
+                        <div className="varActions">
+                          <VariableActions>
+                            <Collapse in={openPrjVars}>
+                              <div className="varUpdate">
+                                <Button
+                                    onClick={() => setUpdateValue(projEnvVar.value, projEnvVar.name, projEnvVar.scope)}
+                                    style={{ all: 'unset'}}
+                                >
+                                  <AddVariable
+                                      varProject={project.name}
+                                      varValues={displayVars}
+                                      varTarget="Project"
+                                      varName={updateVarName}
+                                      varValue={updateVarValue}
+                                      varScope={updateVarScope}
+                                      refresh={onVariableAdded}
+                                      icon="edit"
+                                  />
+                                </Button>
+                              </div>
+                            </Collapse>
+                            <div className="varDelete">
+                              <DeleteVariable
+                                  deleteType="Project variable"
+                                  deleteName={projEnvVar.name}
                                   varProject={project.name}
-                                  varValues={displayVars}
-                                  varTarget="Project"
-                                  varName={updateVarName}
-                                  varValue={updateVarValue}
-                                  varScope={updateVarScope}
+                                  icon="bin"
                                   refresh={onVariableAdded}
-                                  icon="edit"
                               />
-                            </Button>
-                          </div>
-                        </Collapse>
-                        <div className="varDelete">
-                          <DeleteVariable
-                              deleteType="Project variable"
-                              deleteName={projEnvVar.name}
-                              varProject={project.name}
-                              icon="bin"
-                              refresh={onVariableAdded}
-                          />
+                            </div>
+                          </VariableActions>
                         </div>
                       </div>
                     </Fragment>


### PR DESCRIPTION
Update and Delete buttons on the Variables tabs were inheriting shared styles from Organizations, warping the buttons. Updated styling for variable buttons to prevent style bleed from shared css.

![image](https://github.com/uselagoon/lagoon-ui/assets/40746380/0d7b3e49-672c-4ec6-a4f6-d5f1fa5c5c66)
