### PR TITLE
Change: Updated argument naming organizationByID

### DIFF
--- a/src/lib/query/organizations/GroupByNameAndOrganization.js
+++ b/src/lib/query/organizations/GroupByNameAndOrganization.js
@@ -21,7 +21,7 @@ export default gql`
       }
     }
 
-    organization: organizationById (organization: $organization){
+    organization: organizationById (id: $organization){
       id
       name
       description

--- a/src/lib/query/organizations/OrganizationByID.js
+++ b/src/lib/query/organizations/OrganizationByID.js
@@ -7,7 +7,7 @@ import WebhookFragment from 'lib/fragment/Webhook';
 
 export default gql`
   query getOrganization($id: Int!) {
-    organization: organizationById(organization: $id) {
+    organization: organizationById(id: $id) {
       id
       name
       description

--- a/src/lib/query/organizations/OrganizationNotificationsByID.js
+++ b/src/lib/query/organizations/OrganizationNotificationsByID.js
@@ -7,7 +7,7 @@ import WebhookFragment from 'lib/fragment/Webhook';
 
 export default gql`
   query getNotifications($id: Int!){
-    organization: organizationById (organization: $id){
+    organization: organizationById (id: $id){
       id
       name
       description

--- a/src/lib/query/organizations/ProjectAndOrganizationByID.js
+++ b/src/lib/query/organizations/ProjectAndOrganizationByID.js
@@ -22,7 +22,7 @@ export default gql`
       }
     }
 
-    organization: organizationById (organization: $id){
+    organization: organizationById (id: $id){
       id
       name
       quotaGroup

--- a/src/lib/query/organizations/UsersByOrganization.js
+++ b/src/lib/query/organizations/UsersByOrganization.js
@@ -17,7 +17,7 @@ export default gql`
 
 export const getOrganization = gql`
   query getOrganization($id: Int!) {
-    organization: organizationById(organization: $id) {
+    organization: organizationById(id: $id) {
       id
       name
       groups{


### PR DESCRIPTION
Updates the argument naming from `organization` to `id` for `organizationByID` queries.

**Note**: To be merged after the resolver update in PR https://github.com/uselagoon/lagoon/pull/3562