### PR TITLE
Change: Updated addGroupToOrganization mutation to reflect api changes

### DIFF
--- a/src/components/Organizations/NewGroup/index.js
+++ b/src/components/Organizations/NewGroup/index.js
@@ -12,8 +12,8 @@ import styled from 'styled-components';
 import { Footer, StyledNotification } from '../SharedStyles';
 
 const ADD_GROUP_MUTATION = gql`
-  mutation addGroup($group: String!, $organization: Int!) {
-    addGroup(input: { name: $group, organization: $organization }) {
+  mutation addGroupToOrganization($group: String!, $organization: Int!) {
+    addGroupToOrganization(input: { name: $group, organization: $organization }) {
       name
     }
   }


### PR DESCRIPTION
Updates the `addGroup` mutation to `addGroupToOrganization` to reflect changes in the API.

**Note**: To be merged after the resolver update in PR https://github.com/uselagoon/lagoon/pull/3563