### PR TITLE
Truncate deploy keys over 80 characters - New Environment modal

### DIFF
--- a/src/components/NewEnvironment/index.js
+++ b/src/components/NewEnvironment/index.js
@@ -134,7 +134,9 @@ const NewEnvironment = ({
                                   {loadingDK ? <div className="loader"></div>
                                       : !showDKField ?
                                           hashValue(dkValue).substring(0, 25)
-                                          : dkValue
+                                          : dkValue.length > 80 ?
+                                              dkValue.substring(0, 80) + '...'
+                                              : dkValue
                                   }
                                 </div>
                                 <span className="showHide" onClick={() => setShowDKField(!showDKField)}>


### PR DESCRIPTION
Truncates deploy keys over 80 characters within the New Environment modal.

![image](https://github.com/uselagoon/lagoon-ui/assets/40746380/6ae49c6b-4642-4c76-9193-45c3fb286b45)