### PR TITLE
Change: Link edit notification on project to notifications page

### DIFF
--- a/src/components/Organizations/ProjectNotifications/index.js
+++ b/src/components/Organizations/ProjectNotifications/index.js
@@ -2,21 +2,11 @@ import React, { useState } from 'react';
 import { Mutation } from 'react-apollo';
 
 import { EditOutlined } from '@ant-design/icons';
-import { useMutation } from '@apollo/react-hooks';
-import Button from 'components/Button';
-import Modal from 'components/Modal';
 import RemoveProjectGroupConfirm from 'components/Organizations/RemoveProjectGroupConfirm';
 import gql from 'graphql-tag';
-
+import OrgNotificationsLink from 'components/link/Organizations/Notifications';
 import AddNotificationToProject from '../AddNotificationToProject';
-import {
-  UPDATE_NOTIFICATION_EMAIL,
-  UPDATE_NOTIFICATION_ROCKETCHAT,
-  UPDATE_NOTIFICATION_SLACK,
-  UPDATE_NOTIFICATION_TEAMS,
-  UPDATE_NOTIFICATION_WEBHOOK,
-} from '../Notifications';
-import { Footer, ModalChildren, TableActions } from '../SharedStyles';
+import { TableActions } from '../SharedStyles';
 import { StyledProjectNotifications } from './Styles';
 
 const REMOVE_NOTIFICATION_FROM_PROJECT = gql`
@@ -44,165 +34,6 @@ const ProjectNotifications = ({ notifications = [], organizationId, projectName,
     return ['name', '__typename'].includes(key) ? false : true && sortByName;
   });
 
-  const [notificationName, setNotificationName] = useState('');
-  const [email, setEmail] = useState('');
-  const [webhook, setWebhook] = useState('');
-  const [channel, setChannel] = useState('');
-
-  const [updateSlack] = useMutation(UPDATE_NOTIFICATION_SLACK);
-  const [updateRocketChat] = useMutation(UPDATE_NOTIFICATION_ROCKETCHAT);
-  const [updateEmail] = useMutation(UPDATE_NOTIFICATION_EMAIL);
-  const [updateWebhook] = useMutation(UPDATE_NOTIFICATION_WEBHOOK);
-  const [updateTeams] = useMutation(UPDATE_NOTIFICATION_TEAMS);
-
-  const [editModalState, setEditModalState] = useState({
-    open: false,
-    current: {
-      name: '',
-      type: '',
-    },
-  });
-
-  const closeModal = () => {
-    setEditModalState({ open: false, current: { name: '', type: '' } });
-    resetState();
-  };
-
-  const resetState = () => {
-    setNotificationName('');
-    setEmail('');
-    setWebhook('');
-    setChannel('');
-  };
-
-  const getAction = () => {
-    switch (editModalState?.current?.type) {
-      case 'SLACK':
-        return () =>
-          updateSlack({
-            variables: {
-              name: editModalState?.current?.name,
-              patch: {
-                ...(notificationName ? { name: notificationName } : {}),
-                ...(channel ? { channel } : {}),
-                ...(webhook ? { webhook } : {}),
-              },
-            },
-          });
-      case 'ROCKETCHAT':
-        return () =>
-          updateRocketChat({
-            variables: {
-              name: editModalState?.current?.name,
-              patch: {
-                ...(notificationName ? { name: notificationName } : {}),
-                ...(channel ? { channel } : {}),
-                ...(webhook ? { webhook } : {}),
-              },
-            },
-          });
-      case 'EMAIL':
-        return () =>
-          updateEmail({
-            variables: {
-              name: editModalState?.current?.name,
-              patch: {
-                ...(notificationName ? { name: notificationName } : {}),
-                ...(email ? { emailAddress: email } : {}),
-              },
-            },
-          });
-      case 'MICROSOFTTEAMS':
-        return () =>
-          updateTeams({
-            variables: {
-              name: editModalState?.current?.name,
-              patch: {
-                ...(notificationName ? { name: notificationName } : {}),
-                ...(webhook ? { webhook } : {}),
-              },
-            },
-          });
-      case 'WEBHOOK':
-        return () =>
-          updateWebhook({
-            variables: {
-              name: editModalState?.current?.name,
-              patch: {
-                ...(notificationName ? { name: notificationName } : {}),
-                ...(webhook ? { webhook } : {}),
-              },
-            },
-          });
-    }
-  };
-
-  const renderFields = () => {
-    switch (editModalState?.current?.type) {
-      case 'EMAIL':
-        return (
-          <div className="form-box">
-            <label>
-              Email Address: <span style={{ color: '#E30000' }}>*</span>
-              <input
-                className="inputEmail"
-                type="text"
-                placeholder="Enter Email"
-                value={email}
-                onChange={e => setEmail(e.target.value)}
-              />
-            </label>
-          </div>
-        );
-      case 'SLACK':
-      case 'ROCKETCHAT':
-        return (
-          <>
-            <div className="form-box">
-              <label>
-                Webhook: <span style={{ color: '#E30000' }}>*</span>
-                <input
-                  className="inputWebhook"
-                  type="text"
-                  placeholder="Enter Webhook"
-                  value={webhook}
-                  onChange={e => setWebhook(e.target.value)}
-                />
-              </label>
-            </div>
-
-            <div className="form-box">
-              <label>
-                Channel: <span style={{ color: '#E30000' }}>*</span>
-                <input
-                  className="inputChannel"
-                  type="text"
-                  placeholder="Enter channel"
-                  value={channel}
-                  onChange={e => setChannel(e.target.value)}
-                />
-              </label>
-            </div>
-          </>
-        );
-      case 'MICROSOFTTEAMS':
-      case 'WEBHOOK':
-        return (
-          <div className="form-box">
-            <label>
-              Webhook: <span style={{ color: '#E30000' }}>*</span>
-              <input
-                className="inputWebhook"
-                type="text"
-                placeholder="Enter Webhook"
-                value={webhook}
-                onChange={e => setWebhook(e.target.value)}
-              />
-            </label>
-          </div>
-        );
-    }
-  };
   return (
     <StyledProjectNotifications>
       <div className="header" style={{ marginTop: '20px', paddingRight: '0' }}>
@@ -237,21 +68,9 @@ const ProjectNotifications = ({ notifications = [], organizationId, projectName,
                   }
                   return (
                     <TableActions>
-                      <span
-                        className="link"
-                        onClick={() =>
-                          setEditModalState({
-                            open: true,
-                            current: {
-                              name: notification.name,
-                              type: notification.type,
-                            },
-                          })
-                        }
-                      >
+                      <OrgNotificationsLink organizationSlug={organizationId} className="link">
                         <EditOutlined className="edit" />
-                      </span>
-
+                      </OrgNotificationsLink>
                       <RemoveProjectGroupConfirm
                         loading={called}
                         info={{ type: 'notification', projectName: projectName, deleteName: notification.name }}
@@ -274,45 +93,6 @@ const ProjectNotifications = ({ notifications = [], organizationId, projectName,
         ))}
       </div>
 
-      <Modal style={{ content: { width: '50%' } }} isOpen={editModalState.open} onRequestClose={closeModal}>
-        <ModalChildren>
-          <div className="form-box">
-            <label>
-              Name: <span style={{ color: '#E30000' }}>*</span>
-              <input
-                className="inputName"
-                type="text"
-                placeholder="Enter name"
-                value={notificationName || editModalState.current.name}
-                onChange={e => setNotificationName(e.target.value)}
-              />
-            </label>
-          </div>
-          {renderFields()}
-        </ModalChildren>
-
-        <Footer>
-          <Button
-            variant="primary"
-            action={() => {
-              const cb = getAction();
-              cb &&
-                cb()
-                  .then(refresh)
-                  .then(() => {
-                    closeModal();
-                  })
-                  .catch(err => console.error(err));
-            }}
-          >
-            Continue
-          </Button>
-
-          <Button variant="ghost" action={closeModal}>
-            Cancel
-          </Button>
-        </Footer>
-      </Modal>
       <AddNotificationToProject
         projectName={projectName}
         organizationId={organizationId}

--- a/src/components/link/Organizations/Notifications.js
+++ b/src/components/link/Organizations/Notifications.js
@@ -1,9 +1,9 @@
 import Link from 'next/link';
 
-export const getLinkData = (organizationSlug, organizationName) => ({
+export const getLinkData = (organizationSlug) => ({
   urlObject: {
-    pathname: '/organizations/notifications',
-    query: { organizationSlug: organizationSlug, organizationName: organizationName }
+    pathname: `/organizations/notifications`,
+    query: { organizationSlug: organizationSlug },
   },
   asPath: `/organizations/${organizationSlug}/notifications`
 });
@@ -13,12 +13,11 @@ export const getLinkData = (organizationSlug, organizationName) => ({
  */
 const OrgNotificationsLink = ({
   organizationSlug,
-  organizationName,
   children,
-  className = '',
-  prefetch = false
+  className = null,
+  prefetch = false,
 }) => {
-  const linkData = getLinkData(organizationSlug, organizationName);
+  const linkData = getLinkData(organizationSlug);
   return (
     <Link href={linkData.urlObject} as={linkData.asPath} prefetch={prefetch}>
       <a className={className}>{children}</a>
@@ -27,3 +26,4 @@ const OrgNotificationsLink = ({
 };
 
 export default OrgNotificationsLink;
+


### PR DESCRIPTION
Updating a notification on the project page impacts all projects using it, not just the project the user is currently in. The edit button now routes the user to the notifications tab.

![image](https://github.com/uselagoon/lagoon-ui/assets/40746380/112fbf82-946f-4a7a-af56-e29fa24a62ad)
