### PR TITLE
Exposed deploykey via create environment modal

### DIFF
--- a/src/components/NewEnvironment/StyledNewEnvironment.tsx
+++ b/src/components/NewEnvironment/StyledNewEnvironment.tsx
@@ -1,5 +1,6 @@
 import { bp, color, fontSize } from 'lib/variables';
 import styled from 'styled-components';
+import { Collapse } from 'antd';
 
 export const StyledEnvironmentWrapper = styled.div`
     width: 100%;
@@ -97,6 +98,7 @@ export const StyledNewEnvironment = styled.div`
 
 .copied {
   background-color: ${props => props.theme.backgrounds.copy};
+  color: ${props => props.theme.texts.primary};
   ${fontSize(9, 16)};
   border-radius: 3px;
   padding: 0 2px;
@@ -134,6 +136,8 @@ input {
 
 .guide-links {
   margin: 1rem 0;
+  font-size: 1rem;
+  color: ${props => props.theme.texts.primary};
   
   button {
     margin-right: 16px;
@@ -144,6 +148,8 @@ input {
 }
   .docs-link {
     margin-top: 2rem;
+    font-size: 1rem;
+    color: ${props => props.theme.texts.primary};
     
     a {
       text-decoration: underline;
@@ -181,3 +187,24 @@ input {
   }
 }
   `;
+
+export const StyledAntdCollapse = styled(Collapse)`
+  border: none;
+  .ant-collapse-header-text {
+    color: ${props => props.theme.texts.primary};
+    font-size: 1rem;
+  }
+  .ant-collapse-expand-icon {
+    color: ${props => props.theme.texts.primary};
+  }
+  .ant-collapse-header {
+    padding: 0 !important;
+  }
+  .ant-collapse-content-box {
+    padding: 0 !important;
+  }
+  .ant-collapse-item {
+    background-color: ${props => props.theme.backgrounds.primary};
+    border-bottom: 1px solid ${props => props.theme.backgrounds.primary};
+  }
+`;

--- a/src/components/NewEnvironment/StyledNewEnvironment.tsx
+++ b/src/components/NewEnvironment/StyledNewEnvironment.tsx
@@ -46,6 +46,10 @@ export const StyledNewEnvironment = styled.div`
   overflow: visible;
   transform: translateX(-13px);
   align-items: center;
+  
+  &.deploy-key {
+    margin-top: 12px;
+  }
 }
 .copy-btn {
   width: 2rem;

--- a/src/components/NewEnvironment/index.js
+++ b/src/components/NewEnvironment/index.js
@@ -78,6 +78,16 @@ const NewEnvironment = ({
     inputBranchName !== '' ? setShowEnvType(true) : setShowEnvType(false);
   }
 
+  const renderDeploykeyValue = (charLimit) => {
+    if (loadingDK) {
+      return < div className = "loader" > < /div>;
+    }
+    if (!showDKField) {
+      return hashValue(dkValue).substring(0, 25);
+    }
+    return dkValue.length > charLimit ? dkValue.substring(0, charLimit) + '...' : dkValue;
+  }
+
   return (
       <StyledEnvironmentWrapper>
         <div className="margins">
@@ -129,17 +139,11 @@ const NewEnvironment = ({
                             <div className="copy-field deploy-key">
                               <div className="field">
                                 <label>Deploy Key: </label>
-                                {loadingDK ? <div className="loader"></div>
-                                    : !showDKField ?
-                                        hashValue(dkValue).substring(0, 25)
-                                        : dkValue.length > 65 ?
-                                            dkValue.substring(0, 65) + '...'
-                                            : dkValue
-                                }
+                                { renderDeploykeyValue(65)}
                               </div>
                               <span className="showHide" onClick={() => setShowDKField(!showDKField)}>
                                   <Image
-                                      src={showDKField ? show : hide}
+                                      src={!showDKField ? show : hide}
                                       className="showHide"
                                       style={{all: "unset"}}
                                       alt=""
@@ -169,17 +173,11 @@ const NewEnvironment = ({
                             <div className="showHideContainer">
                               <div className="copy-field">
                                 <div className="field">
-                                  {loadingDK ? <div className="loader"></div>
-                                      : !showDKField ?
-                                          hashValue(dkValue).substring(0, 25)
-                                          : dkValue.length > 80 ?
-                                              dkValue.substring(0, 80) + '...'
-                                              : dkValue
-                                  }
+                                  { renderDeploykeyValue(80)}
                                 </div>
                                 <span className="showHide" onClick={() => setShowDKField(!showDKField)}>
                                   <Image
-                                      src={showDKField ? show : hide}
+                                      src={!showDKField ? show : hide}
                                       className="showHide"
                                       style={{all: "unset"}}
                                       alt=""

--- a/src/components/NewEnvironment/index.js
+++ b/src/components/NewEnvironment/index.js
@@ -8,19 +8,21 @@ import Image from "next/image";
 import show from "../../static/images/show.svg";
 import hide from "../../static/images/hide.svg";
 import { CopyToClipboard } from "react-copy-to-clipboard";
-import {StyledNewEnvironment, StyledEnvironmentWrapper} from './StyledNewEnvironment';
+import {StyledNewEnvironment, StyledEnvironmentWrapper, StyledAntdCollapse} from './StyledNewEnvironment';
 import {useQuery} from "@apollo/react-hooks";
 import ProjectByNameWithDeployKeyQuery from "../../lib/query/ProjectByNameWithDeployKey";
 import { Footer } from '../Organizations/SharedStyles';
 import getConfig from "next/config";
 import NewEnvironmentButton from "./NewEnvironmentButton";
 const { WEBHOOK_URL } = getConfig().publicRuntimeConfig;
+import { CaretRightOutlined } from '@ant-design/icons';
+import { Collapse } from 'antd';
 
 const DEPLOY_ENVIRONMENT_BRANCH_MUTATION = gql`
   mutation (
     $project: String!,
     $branch: String!,
-    ) {
+  ) {
     deployEnvironmentBranch(input: {
       project:{
         name: $project
@@ -46,17 +48,17 @@ const hashValue = (value) => {
 };
 
 const NewEnvironment = ({
- inputProjectName,
- productionEnvironment,
- environmentCount,
- inputBranchName,
- setBranchName,
- open,
- openModal,
- closeModal,
- refresh,
- setClear,
- }) => {
+  inputProjectName,
+  productionEnvironment,
+  environmentCount,
+  inputBranchName,
+  setBranchName,
+  open,
+  openModal,
+  closeModal,
+  refresh,
+  setClear,
+}) => {
   const webhookURL = WEBHOOK_URL ? WEBHOOK_URL : 'https://webhook-handler.example.com';
   let dkValue = "●●●●●●●●●●●●●●●●●●●●●●●●●"
   const [copiedDK, setCopiedDK] = useState(false);
@@ -88,6 +90,109 @@ const NewEnvironment = ({
     return dkValue.length > charLimit ? dkValue.substring(0, charLimit) + '...' : dkValue;
   }
 
+  const renderStep2 = (header) => {
+    return (
+      <div className="modal-step">
+        {header ? <p><b>Step 2: </b>Add this project's Deploy Key to your Git service.</p> : null}
+        <div className="showHideContainer">
+          <div className="copy-field">
+            <div className="field">
+              { renderDeploykeyValue(80)}
+            </div>
+            <span className="showHide" onClick={() => setShowDKField(!showDKField)}>
+            <Image
+              src={!showDKField ? show : hide}
+              className="showHide"
+              style={{all: "unset"}}
+              alt=""
+            />
+            </span>
+            <span className="copied" style={copiedDK ? {top: '-20px', opacity: '0'} : null}>
+              Copied
+            </span>
+            <CopyToClipboard
+              text={dkValue}
+              onCopy={() => {
+                setCopiedDK(true);
+                setTimeout(function () {
+                  setCopiedDK(false);
+                }, 750);
+              }}
+            >
+            <span className="copy"/>
+            </CopyToClipboard>
+          </div>
+        </div>
+        <div className="guide-links">
+          <p>Step by step guides</p>
+          <div className="addEnvLinks">
+            <a href="https://docs.github.com/en/developers/overview/managing-deploy-keys#deploy-keys"
+               target="_blank"><Button>Github</Button></a>
+            <a href="https://docs.gitlab.com/ee/user/project/deploy_keys/"
+               target="_blank"><Button>GitLab</Button></a>
+            <a href="https://support.atlassian.com/bitbucket-cloud/docs/add-access-keys/"
+               target="_blank"><Button>Bitbucket</Button></a>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  const renderStep3 = (header) => {
+    return (
+      <div className="modal-step">
+        {header ? <p><b>Step 3: </b>Add the webhook to your Git service</p> : null}
+        <div className="showHideContainer">
+          <div className="copy-field">
+            <div className="field">
+              { webhookURL }
+            </div>
+            <div className="copy-btn">
+              <span className="copied" style={copiedWH ? { top: '-20px', opacity: '0' } : null}>
+                Copied
+              </span>
+              <CopyToClipboard
+                text={webhookURL}
+                onCopy={() => {
+                  setCopiedWH(true);
+                  setTimeout(function () {
+                    setCopiedWH(false);
+                  }, 750);
+                }}
+              >
+                <span className="copy" />
+              </CopyToClipboard>
+            </div>
+          </div>
+        </div>
+        <div className="guide-links">
+          <p>Step by step guides</p>
+          <div className="addEnvLinks">
+            <a href="https://docs.github.com/en/developers/webhooks-and-events/webhooks/creating-webhooks" target="_blank"><Button>Github</Button></a>
+            <a href="https://docs.gitlab.com/ee/user/project/integrations/webhooks.html" target="_blank"><Button>GitLab</Button></a>
+            <a href="https://support.atlassian.com/bitbucket-cloud/docs/manage-webhooks/" target="_blank"><Button>Bitbucket</Button></a>
+          </div>
+        </div>
+        <div className="docs-link">
+          <p>Please ensure that all these steps have been completed before creating your new environment. Follow the <a href="https://docs.lagoon.sh/installing-lagoon/add-project/#add-the-deploy-key-to-your-git-repository" target="_blank">Lagoon Docs</a> for more details.</p>
+        </div>
+      </div>
+    )
+  }
+
+  const items = () => [
+    {
+      key: '1',
+      label: <p><b>Step 2: </b>Add this project's Deploy Key to your Git service.</p>,
+      children: renderStep2(),
+    },
+    {
+      key: '2',
+      label: <p><b>Step 3: </b>Add the webhook to your Git service</p>,
+      children: renderStep3(),
+    },
+  ];
+
   return (
       <StyledEnvironmentWrapper>
         <div className="margins">
@@ -109,7 +214,7 @@ const NewEnvironment = ({
                 const regex = new RegExp(errors.join("|"), "i");
                 const err = regex.test(data && data.deployEnvironmentBranch);
                 if (data && !err) {
-                    refresh().then(setClear).then(closeModal);
+                  refresh().then(setClear).then(closeModal);
                 }
 
                 return (
@@ -124,7 +229,7 @@ const NewEnvironment = ({
                             <label>
                               Branch name: <span style={{ color: '#E30000' }}>*</span>
                             </label>
-                              <input
+                            <input
                                 id="branchName"
                                 className="inputBranch"
                                 type="text"
@@ -132,124 +237,19 @@ const NewEnvironment = ({
                                 value={inputBranchName}
                                 onChange={setBranchName}
                                 onBlur={() => toggleShowEnvType()}
-                              />
+                            />
                           </div>
-                          { environmentCount > 0 &&
-                          <div className="showHideContainer">
-                            <div className="copy-field deploy-key">
-                              <div className="field">
-                                <label>Deploy Key: </label>
-                                { renderDeploykeyValue(65)}
-                              </div>
-                              <span className="showHide" onClick={() => setShowDKField(!showDKField)}>
-                                  <Image
-                                      src={!showDKField ? show : hide}
-                                      className="showHide"
-                                      style={{all: "unset"}}
-                                      alt=""
-                                  />
-                                </span>
-                              <span className="copied" style={copiedDK ? {top: '-20px', opacity: '0'} : null}>
-                                  Copied
-                                </span>
-                              <CopyToClipboard
-                                  text={dkValue}
-                                  onCopy={() => {
-                                    setCopiedDK(true);
-                                    setTimeout(function () {
-                                      setCopiedDK(false);
-                                    }, 750);
-                                  }}
-                              >
-                                <span className="copy deploy-key"/>
-                              </CopyToClipboard>
-                            </div>
-                          </div>
-                          }
                         </div>
-                        { environmentCount <= 0 &&
-                          <div className="modal-step">
-                            <p><b>Step 2: </b>Add this project's Deploy Key to your Git service.</p>
-                            <div className="showHideContainer">
-                              <div className="copy-field">
-                                <div className="field">
-                                  { renderDeploykeyValue(80)}
-                                </div>
-                                <span className="showHide" onClick={() => setShowDKField(!showDKField)}>
-                                  <Image
-                                      src={!showDKField ? show : hide}
-                                      className="showHide"
-                                      style={{all: "unset"}}
-                                      alt=""
-                                  />
-                                </span>
-                                <span className="copied" style={copiedDK ? {top: '-20px', opacity: '0'} : null}>
-                                  Copied
-                                </span>
-                                <CopyToClipboard
-                                    text={dkValue}
-                                    onCopy={() => {
-                                      setCopiedDK(true);
-                                      setTimeout(function () {
-                                        setCopiedDK(false);
-                                      }, 750);
-                                    }}
-                                >
-                                  <span className="copy"/>
-                                </CopyToClipboard>
-                              </div>
-                            </div>
-                            <div className="guide-links">
-                              <p>Step by step guides</p>
-                              <div className="addEnvLinks">
-                                <a href="https://docs.github.com/en/developers/overview/managing-deploy-keys#deploy-keys"
-                                   target="_blank"><Button>Github</Button></a>
-                                <a href="https://docs.gitlab.com/ee/user/project/deploy_keys/"
-                                   target="_blank"><Button>GitLab</Button></a>
-                                <a href="https://support.atlassian.com/bitbucket-cloud/docs/add-access-keys/"
-                                   target="_blank"><Button>Bitbucket</Button></a>
-                              </div>
-                            </div>
-                          </div>
-                        }
-                        { environmentCount <= 0 &&
-                          <div className="modal-step">
-                            <p><b>Step 3: </b>Add the webhook to your Git service</p>
-                            <div className="showHideContainer">
-                              <div className="copy-field">
-                                <div className="field">
-                                  { webhookURL }
-                                </div>
-                                <div className="copy-btn">
-                                  <span className="copied" style={copiedWH ? { top: '-20px', opacity: '0' } : null}>
-                                    Copied
-                                  </span>
-                                  <CopyToClipboard
-                                      text={webhookURL}
-                                      onCopy={() => {
-                                        setCopiedWH(true);
-                                        setTimeout(function () {
-                                          setCopiedWH(false);
-                                        }, 750);
-                                      }}
-                                  >
-                                    <span className="copy" />
-                                  </CopyToClipboard>
-                                </div>
-                              </div>
-                            </div>
-                            <div className="guide-links">
-                              <p>Step by step guides</p>
-                              <div className="addEnvLinks">
-                                <a href="https://docs.github.com/en/developers/webhooks-and-events/webhooks/creating-webhooks" target="_blank"><Button>Github</Button></a>
-                                <a href="https://docs.gitlab.com/ee/user/project/integrations/webhooks.html" target="_blank"><Button>GitLab</Button></a>
-                                <a href="https://support.atlassian.com/bitbucket-cloud/docs/manage-webhooks/" target="_blank"><Button>Bitbucket</Button></a>
-                              </div>
-                            </div>
-                            <div className="docs-link">
-                              <p>Please ensure that all these steps have been completed before creating your new environment. Follow the <a href="https://docs.lagoon.sh/installing-lagoon/add-project/#add-the-deploy-key-to-your-git-repository" target="_blank">Lagoon Docs</a> for more details.</p>
-                            </div>
-                          </div>
+                        { environmentCount > 0 ?
+                            <StyledAntdCollapse>
+                              <Collapse
+                                  items={items()}
+                                  bordered={false}
+                                  expandIcon={({ isActive }) => <CaretRightOutlined rotate={isActive ? 90 : 0} />}
+                              />
+                            </StyledAntdCollapse>
+                            :
+                            [renderStep2("header"), renderStep3("header")]
                         }
                         <div>
                           <Footer>

--- a/src/components/NewEnvironment/index.js
+++ b/src/components/NewEnvironment/index.js
@@ -124,6 +124,44 @@ const NewEnvironment = ({
                                 onBlur={() => toggleShowEnvType()}
                               />
                           </div>
+                          { environmentCount > 0 &&
+                          <div className="showHideContainer">
+                            <div className="copy-field deploy-key">
+                              <div className="field">
+                                <label>Deploy Key: </label>
+                                {loadingDK ? <div className="loader"></div>
+                                    : !showDKField ?
+                                        hashValue(dkValue).substring(0, 25)
+                                        : dkValue.length > 65 ?
+                                            dkValue.substring(0, 65) + '...'
+                                            : dkValue
+                                }
+                              </div>
+                              <span className="showHide" onClick={() => setShowDKField(!showDKField)}>
+                                  <Image
+                                      src={showDKField ? show : hide}
+                                      className="showHide"
+                                      style={{all: "unset"}}
+                                      alt=""
+                                  />
+                                </span>
+                              <span className="copied" style={copiedDK ? {top: '-20px', opacity: '0'} : null}>
+                                  Copied
+                                </span>
+                              <CopyToClipboard
+                                  text={dkValue}
+                                  onCopy={() => {
+                                    setCopiedDK(true);
+                                    setTimeout(function () {
+                                      setCopiedDK(false);
+                                    }, 750);
+                                  }}
+                              >
+                                <span className="copy deploy-key"/>
+                              </CopyToClipboard>
+                            </div>
+                          </div>
+                          }
                         </div>
                         { environmentCount <= 0 &&
                           <div className="modal-step">


### PR DESCRIPTION
Instead of hiding Step 2 & 3 when one or more environments are present, they are now wrapped in a collapsable drop-down. This is closed by default but allows users to view the `deploykey` & `webhook` if required.

![image](https://github.com/uselagoon/lagoon-ui/assets/40746380/53531c73-181e-4241-9773-cb6298e9aede)


Workaround for https://github.com/uselagoon/lagoon-ui/issues/191 until the page & components are redesigned.