### PR TITLE
Change: Allow for empty variable values

### DIFF
--- a/src/components/AddVariable/index.js
+++ b/src/components/AddVariable/index.js
@@ -45,6 +45,7 @@ export const AddVariable = ({
   openModal,
   closeModal,
   setClear,
+  action,
 }) => {
   const [updateName, setUpdateName] = useState(varName);
   const [updateValue, setUpdateValue] = useState(varValue);
@@ -155,7 +156,7 @@ export const AddVariable = ({
                   refresh().then(setClear).then(closeModal);
                 }
 
-                if (inputValue === '' && updateValue !== undefined && updateValue !== '' || inputValue !== '' && updateValue === undefined) {
+                if (action === "add" && inputValue !== '' || action === "edit" && updateValue !== '') {
                   if (updateVar && called || updateName && called ) {
                     return <div>Updating variable</div>;
                   } else if (called) {
@@ -180,10 +181,10 @@ export const AddVariable = ({
                   }, 1000);
                 };
 
-                if (inputValue === '' && updateValue === '' || inputValue === '' && updateValue === undefined) {
+                if (action === "add" && inputValue === '' || action === "edit" && updateValue === '') {
                   return (
                     <Popconfirm
-                      title="No value set"
+                      title="No value set for this variable."
                       description="Are you sure you want to continue?"
                       open={openPop}
                       onConfirm={addOrUpdateEnvVariableHandler}

--- a/src/components/AddVariable/index.js
+++ b/src/components/AddVariable/index.js
@@ -62,15 +62,15 @@ export const AddVariable = ({
     setUpdateValue(varValue);
     setUpdateName(varName);
     setUpdateScope(varScope);
-  }, [varValue]);
+  }, [varName, varValue]);
 
   return (
       <NewVariable>
       {
         icon ?
-            <Button variant='white' icon={icon} action={openModal}>
-              Update
-            </Button>
+          <Button variant='white' icon={icon} action={openModal}>
+            Update
+          </Button>
           :
           <ButtonBootstrap onClick={openModal}>
             {
@@ -102,7 +102,7 @@ export const AddVariable = ({
                 name="results"
                 value={varScope ? scopeOptions.find((o) => o.value === updateScope.toUpperCase()) : scopeOptions.find((o) => o.value === inputScope)}
                 onChange={varScope ? (selectedOption) => setUpdateScope(selectedOption.value)
-                    : (selectedOption) => setInputScope(selectedOption.value)
+                  : (selectedOption) => setInputScope(selectedOption.value)
                 }
                 options={scopeOptions}
                 required
@@ -156,10 +156,10 @@ export const AddVariable = ({
                   refresh().then(setClear).then(closeModal);
                 }
 
-                if (action === "add" && inputValue !== '' || action === "edit" && updateValue !== '') {
-                  if (updateVar && called || updateName && called ) {
+                if (action === "add" && inputValue !== '' || action === "edit" && updateValue !== '' || action === "edit" && inputValue !== '') {
+                  if (action === "edit" && called ) {
                     return <div>Updating variable</div>;
-                  } else if (called) {
+                  } else if (action === "add" && called) {
                     return <div>Adding variable</div>;
                   }
                 }
@@ -181,7 +181,7 @@ export const AddVariable = ({
                   }, 1000);
                 };
 
-                if (action === "add" && inputValue === '' || action === "edit" && updateValue === '') {
+                if (action === "add" && inputValue === '' || action === "edit" && updateValue === '' && inputValue === '') {
                   return (
                     <Popconfirm
                       title="No value set for this variable."

--- a/src/components/AddVariable/index.js
+++ b/src/components/AddVariable/index.js
@@ -6,7 +6,8 @@ import ReactSelect from "react-select";
 import { Mutation } from "react-apollo";
 import withLogic from "components/AddVariable/logic";
 import addOrUpdateEnvVariableMutation from "../../lib/mutation/AddOrUpdateEnvVariableByName";
-import { NewVariable, NewVariableModal, custom } from "./StyledAddVariable";
+import { NewVariable, NewVariableModal } from "./StyledAddVariable";
+import { Popconfirm } from 'antd';
 
 /**
  * Adds a Variable.
@@ -48,7 +49,14 @@ export const AddVariable = ({
   const [updateName, setUpdateName] = useState(varName);
   const [updateValue, setUpdateValue] = useState(varValue);
   const [updateScope, setUpdateScope] = useState(varScope);
+  const [openPop, setOpenPop] = useState(false);
   const handleUpdateValue = (event) => {setUpdateValue(event.target.value)};
+  const handlePopCancel = () => {
+    setOpenPop(false);
+  };
+  const showPopconfirm = () => {
+    setOpenPop(true);
+  };
   useEffect(() => {
     setUpdateValue(varValue);
     setUpdateName(varName);
@@ -128,7 +136,7 @@ export const AddVariable = ({
               cancel
             </a>
             <Mutation mutation={addOrUpdateEnvVariableMutation}>
-              {(addOrUpdateEnvVariableByName, { called, error, data }) => {
+              {(addOrUpdateEnvVariableByName, { called, error, data, loading }) => {
                 let updateVar = varValues.map((varName) => {
                   return varName.name;
                 });
@@ -147,10 +155,12 @@ export const AddVariable = ({
                   refresh().then(setClear).then(closeModal);
                 }
 
-                if (updateVar && called || updateName && called ) {
-                  return <div>Updating variable</div>;
-                } else if (called) {
-                  return <div>Adding variable</div>;
+                if (inputValue === '' && updateValue !== undefined && updateValue !== '' || inputValue !== '' && updateValue === undefined) {
+                  if (updateVar && called || updateName && called ) {
+                    return <div>Updating variable</div>;
+                  } else if (called) {
+                    return <div>Adding variable</div>;
+                  }
                 }
 
                 const addOrUpdateEnvVariableHandler = () => {
@@ -165,26 +175,62 @@ export const AddVariable = ({
                       },
                     },
                   });
+                  setTimeout(() => {
+                    setOpenPop(false);
+                  }, 1000);
                 };
 
-                return (
-                  <ButtonBootstrap
-                    disabled={ updateName ?
-                      updateName === "" || updateValue === "" || updateScope === ""
-                        :
-                      inputName === "" || inputValue === "" || inputScope === ""
-                    }
-                    onClick={addOrUpdateEnvVariableHandler}
-                  >
-                    {varTarget == "Environment"
-                      ? updateVar || varName
-                        ? "Update environment variable"
-                        : "Add environment variable"
-                      : updateVar || varName
-                      ? "Update project variable"
-                      : "Add project variable"}
-                  </ButtonBootstrap>
-                );
+                if (inputValue === '' && updateValue === '' || inputValue === '' && updateValue === undefined) {
+                  return (
+                    <Popconfirm
+                      title="No value set"
+                      description="Are you sure you want to continue?"
+                      open={openPop}
+                      onConfirm={addOrUpdateEnvVariableHandler}
+                      okButtonProps={{
+                        loading: loading,
+                      }}
+                      onCancel={handlePopCancel}
+                    >
+                      <ButtonBootstrap
+                        disabled={ updateName ?
+                          updateName === "" || updateScope === ""
+                          :
+                          inputName === "" || inputScope === ""
+                        }
+                        onClick={showPopconfirm}
+                      >
+                        {varTarget === "Environment"
+                          ? updateVar || varName
+                              ? "Update environment variable"
+                              : "Add environment variable"
+                          : updateVar || varName
+                              ? "Update project variable"
+                              : "Add project variable"}
+                      </ButtonBootstrap>
+                    </Popconfirm>
+                  );
+                } else {
+                  return (
+                    <ButtonBootstrap
+                      disabled={ updateName ?
+                          updateName === "" || updateScope === ""
+                          :
+                          inputName === "" || inputScope === ""
+                      }
+                      onClick={addOrUpdateEnvVariableHandler}
+                    >
+                      {varTarget === "Environment"
+                        ? updateVar || varName
+                            ? "Update environment variable"
+                            : "Add environment variable"
+                        : updateVar || varName
+                            ? "Update project variable"
+                            : "Add project variable"}
+                    </ButtonBootstrap>
+                  )
+                }
+
               }}
             </Mutation>
           </div>

--- a/src/components/EnvironmentVariables/index.js
+++ b/src/components/EnvironmentVariables/index.js
@@ -20,6 +20,7 @@ import show from "../../static/images/show.svg";
 import hide from "../../static/images/hide.svg";
 import ProjectVariablesLink from "components/link/ProjectVariables";
 import Alert from 'components/Alert'
+import {Tag} from "antd";
 
 /**
  * Displays the environment variable information.
@@ -208,7 +209,6 @@ const EnvironmentVariables = ({ environment, onVariableAdded }) => {
               </div>
               <div className="data-table">
                 {displayVars.map((envVar, index) => {
-                  envVar.value === '' ? envVar.value = '-' : envVar.value
                   return (
                     <Fragment key={index}>
                       <div
@@ -224,10 +224,23 @@ const EnvironmentVariables = ({ environment, onVariableAdded }) => {
                               <div className="loader"></div>
                             </div>
                           </Collapse>
-                        ) : envVar.value ? (
+                        ) : envVar.value !== undefined ? (
                           <Collapse in={openEnvVars}>
                             <div className="varValue" id={index}>
-                              {envVar.value.length <= 100 &&
+                              {envVar.value.length === 0 &&
+                              valueState[index] ? (
+                                <div className="showHideContainer">
+                                  <Tag color="#4578e6">Empty</Tag>
+                                  <span onClick={() => valuesHide(index)}>
+                                  <Image
+                                    src={hide}
+                                    className="showHide"
+                                    style={{ all: "unset" }}
+                                    alt=""
+                                  />
+                                  </span>
+                                </div>
+                              ) : envVar.value.length <= 100 &&
                               !valueState[index] ? (
                                 <div className="showHideContainer">
                                   {hashValue(envVar.value).substring(0, 25)}
@@ -412,7 +425,6 @@ const EnvironmentVariables = ({ environment, onVariableAdded }) => {
               </div>
               <div className="data-table">
                 {displayProjectVars.map((projEnvVar, index) => {
-                  projEnvVar.value === '' ? projEnvVar.value = '-' : projEnvVar.value
                   return (
                     <Fragment key={index}>
                       <div
@@ -428,10 +440,23 @@ const EnvironmentVariables = ({ environment, onVariableAdded }) => {
                               <div className="loader"></div>
                             </div>
                           </Collapse>
-                        ) : projEnvVar.value ? (
+                        ) : projEnvVar.value !== undefined ? (
                           <Collapse in={openPrjVars}>
                             <div className="varValue" id={index}>
-                              {projEnvVar.value.length <= 100 &&
+                              {projEnvVar.value.length == 0 &&
+                              prjValueState[index] ? (
+                                <div className="showHideContainer">
+                                  <Tag color="#4578e6">Empty</Tag>
+                                  <span onClick={() => prjValuesHide(index)}>
+                                  <Image
+                                    src={hide}
+                                    className="showHide"
+                                    style={{ all: "unset" }}
+                                    alt=""
+                                  />
+                                  </span>
+                                </div>
+                              ) : projEnvVar.value.length <= 100 &&
                               !prjValueState[index] ? (
                                 <div className="showHideContainer">
                                   {hashValue(projEnvVar.value).substring(0, 25)}

--- a/src/components/EnvironmentVariables/index.js
+++ b/src/components/EnvironmentVariables/index.js
@@ -153,14 +153,14 @@ const EnvironmentVariables = ({ environment, onVariableAdded }) => {
         <>
           {
             environmentErrorAlert && (
-              <Alert 
+              <Alert
                 type="error"
                 closeAlert={closeEnvironmentError}
                 header="Unauthorized:"
                 message="You don't have permission to view environment variable values. Contact your administrator to obtain the relevant permissions."
               />
             )
-          }         
+          }
           <div className="header">
             <label>Environment Variables</label>
             <div className="header-buttons">
@@ -206,6 +206,7 @@ const EnvironmentVariables = ({ environment, onVariableAdded }) => {
               </div>
               <div className="data-table">
                 {displayVars.map((envVar, index) => {
+                  envVar.value === '' ? envVar.value = '-' : envVar.value
                   return (
                     <Fragment key={index}>
                       <div
@@ -359,7 +360,7 @@ const EnvironmentVariables = ({ environment, onVariableAdded }) => {
           <hr style={{ margin: "30px 0" }} />
           {
             projectErrorAlert && (
-              <Alert 
+              <Alert
                 type="error"
                 closeAlert={closeProjectError}
                 header="Unauthorized:"
@@ -408,6 +409,7 @@ const EnvironmentVariables = ({ environment, onVariableAdded }) => {
               </div>
               <div className="data-table">
                 {displayProjectVars.map((projEnvVar, index) => {
+                  projEnvVar.value === '' ? projEnvVar.value = '-' : projEnvVar.value
                   return (
                     <Fragment key={index}>
                       <div

--- a/src/components/EnvironmentVariables/index.js
+++ b/src/components/EnvironmentVariables/index.js
@@ -142,6 +142,7 @@ const EnvironmentVariables = ({ environment, onVariableAdded }) => {
               varTarget="Environment"
               noVars="Add"
               refresh={onVariableAdded}
+              action="add"
             />
           </div>
           <hr style={{ margin: "30px 0" }} />
@@ -174,6 +175,7 @@ const EnvironmentVariables = ({ environment, onVariableAdded }) => {
                   varValues={displayVars}
                   varTarget="Environment"
                   refresh={onVariableAdded}
+                  action="add"
                 />
               </Button>
               <Button
@@ -302,15 +304,16 @@ const EnvironmentVariables = ({ environment, onVariableAdded }) => {
                                   style={{ all: 'unset'}}
                                 >
                                   <AddVariable
-                                      varProject={environment.project.name}
-                                      varEnvironment={environment.name}
-                                      varValues={displayVars}
-                                      varTarget="Environment"
-                                      varName={updateVarName}
-                                      varValue={updateVarValue}
-                                      varScope={updateVarScope}
-                                      refresh={onVariableAdded}
-                                      icon="edit"
+                                    varProject={environment.project.name}
+                                    varEnvironment={environment.name}
+                                    varValues={displayVars}
+                                    varTarget="Environment"
+                                    varName={updateVarName}
+                                    varValue={updateVarValue}
+                                    varScope={updateVarScope}
+                                    refresh={onVariableAdded}
+                                    icon="edit"
+                                    action="edit"
                                   />
                                 </Button>
                               </div>

--- a/src/components/ProjectVariables/index.js
+++ b/src/components/ProjectVariables/index.js
@@ -161,6 +161,7 @@ const ProjectVariables = ({ project, onVariableAdded, closeModal }) => {
               </div>
               <div className="data-table">
                 {displayVars.map((projEnvVar, index) => {
+                  projEnvVar.value === '' ? projEnvVar.value = '-' : projEnvVar.value
                   return (
                     <Fragment key={index}>
                       <div

--- a/src/components/ProjectVariables/index.js
+++ b/src/components/ProjectVariables/index.js
@@ -97,6 +97,7 @@ const ProjectVariables = ({ project, onVariableAdded, closeModal }) => {
               varValues={displayVars}
               varTarget="Project"
               refresh={onVariableAdded}
+              action="add"
             />
           </div>
           <hr style={{ margin: "30px 0" }} />
@@ -129,6 +130,7 @@ const ProjectVariables = ({ project, onVariableAdded, closeModal }) => {
                   varValues={displayVars}
                   varTarget="Project"
                   refresh={onVariableAdded}
+                  action="add"
                 />
               </Button>
               <Button
@@ -260,14 +262,15 @@ const ProjectVariables = ({ project, onVariableAdded, closeModal }) => {
                                     style={{ all: 'unset'}}
                                 >
                                   <AddVariable
-                                      varProject={project.name}
-                                      varValues={displayVars}
-                                      varTarget="Project"
-                                      varName={updateVarName}
-                                      varValue={updateVarValue}
-                                      varScope={updateVarScope}
-                                      refresh={onVariableAdded}
-                                      icon="edit"
+                                    varProject={project.name}
+                                    varValues={displayVars}
+                                    varTarget="Project"
+                                    varName={updateVarName}
+                                    varValue={updateVarValue}
+                                    varScope={updateVarScope}
+                                    refresh={onVariableAdded}
+                                    icon="edit"
+                                    action="edit"
                                   />
                                 </Button>
                               </div>

--- a/src/components/ProjectVariables/index.js
+++ b/src/components/ProjectVariables/index.js
@@ -17,6 +17,7 @@ import {
 } from "./StyledProjectVariables";
 import DeleteVariable from "components/DeleteVariable";
 import Alert from 'components/Alert'
+import {Tag} from "antd";
 
 /**
  * Displays the projects variable information.
@@ -163,7 +164,6 @@ const ProjectVariables = ({ project, onVariableAdded, closeModal }) => {
               </div>
               <div className="data-table">
                 {displayVars.map((projEnvVar, index) => {
-                  projEnvVar.value === '' ? projEnvVar.value = '-' : projEnvVar.value
                   return (
                     <Fragment key={index}>
                       <div
@@ -179,10 +179,23 @@ const ProjectVariables = ({ project, onVariableAdded, closeModal }) => {
                               <div className="loader"></div>
                             </div>
                           </Collapse>
-                        ) : projEnvVar.value ? (
+                        ) : projEnvVar.value !== undefined ? (
                           <Collapse in={openPrjVars}>
                             <div className="varValue" id={index}>
-                              {projEnvVar.value.length <= 100 &&
+                              {projEnvVar.value.length === 0 &&
+                              valueState[index] ? (
+                                <div className="showHideContainer">
+                                  <Tag color="#4578e6">Empty</Tag>
+                                  <span onClick={() => valuesHide(index)}>
+                                  <Image
+                                    src={hide}
+                                    className="showHide"
+                                    style={{ all: "unset" }}
+                                    alt=""
+                                  />
+                                  </span>
+                                </div>
+                              ) : projEnvVar.value.length <= 100 &&
                               !valueState[index] ? (
                                 <div className="showHideContainer">
                                   {hashValue(projEnvVar.value).substring(0, 25)}


### PR DESCRIPTION
Updates the Variables tabs to allow for variables to be created/updated with no value defined.
Includes confirm pop-up when adding/updating variable to have a null value.

![image](https://github.com/uselagoon/lagoon-ui/assets/40746380/9322a2c8-1891-4745-88af-063f9466f391)

Displays empty variables with a `Tag` component:

![image](https://github.com/uselagoon/lagoon-ui/assets/40746380/9e2db6a2-eb09-425f-aeab-f32bb80ceec2)
