### PR TITLE
feat: support setting the idp hint as an envvar

### DIFF
--- a/src/lib/withKeycloak.js
+++ b/src/lib/withKeycloak.js
@@ -35,7 +35,7 @@ export default (App, initialAuth) => {
 
       if (!keycloak.authenticated) {
         const urlQuery = queryStringToObject(location.search);
-        const options = urlQuery.idpHint ? { idpHint: urlQuery.idpHint } : {};
+        const options = urlQuery.idpHint ? { idpHint: urlQuery.idpHint } : { idpHint: publicRuntimeConfig.KEYCLOAK_IDPHINT };
 
         await keycloak.login(options);
       }

--- a/src/next.config.js
+++ b/src/next.config.js
@@ -16,6 +16,7 @@ module.exports = {
     GRAPHQL_API_TOKEN: process.env.GRAPHQL_API_TOKEN,
     GRAPHQL_API: process.env.GRAPHQL_API,
     KEYCLOAK_API: process.env.KEYCLOAK_API,
+    KEYCLOAK_IDPHINT: process.env.KEYCLOAK_IDPHINT,
     LAGOON_UI_ICON: process.env.LAGOON_UI_ICON,
     LAGOON_UI_TASK_BLOCKLIST: taskBlocklist,
     LAGOON_VERSION: process.env.LAGOON_VERSION,


### PR DESCRIPTION
This lets you set an IDP hint for the UI to use so that it can pass directly to a specific IDP instead of the default keycloak login.

This could be used to deploy a UI for a specific IDP