### PR TITLE
move hovertags below status text for deps/bulkdeps/depsbyfilter

### DIFF
--- a/src/components/BulkDeployments/StyledBulkDeployments.tsx
+++ b/src/components/BulkDeployments/StyledBulkDeployments.tsx
@@ -87,7 +87,10 @@ export const BulkDeploymentsDataTable = styled.div`
     .priority {
       width: 8%;
     }
-
+    .buildstep{
+      display:flex;
+      flex-direction:column;
+    }
     .status {
       @media ${bp.xs_smallOnly} {
         margin-left: 20px;

--- a/src/components/BulkDeployments/index.tsx
+++ b/src/components/BulkDeployments/index.tsx
@@ -72,7 +72,7 @@ const BulkDeployments: FC<BulkDeploymentsProps> = ({ deployments }) => (
           </div>
           <div className="priority">{deployment.priority}</div>
           <div className="started">{moment.utc(deployment.created).local().format('DD MMM YYYY, HH:mm:ss (Z)')}</div>
-          <div className={`status ${deployment.status}`}>
+          <div className={`status buildstep ${deployment.status}`}>
             <span>{deployment.status.charAt(0).toUpperCase() + deployment.status.slice(1)} </span>
             {!['complete', 'cancelled', 'failed'].includes(deployment.status) && deployment.buildStep && (
               <HoverTag text={deployment.buildStep} maxWidth="160px" />

--- a/src/components/Deployments/StyledDeployments.tsx
+++ b/src/components/Deployments/StyledDeployments.tsx
@@ -117,6 +117,10 @@ export const StyledDeployments = styled.div`
       .warning {
         width: 15px;
       }
+      .buildstep{
+        display:flex;
+        flex-direction:column;
+      }
       .status {
         @media ${bp.xs_smallOnly} {
           margin-left: 20px;

--- a/src/components/Deployments/index.tsx
+++ b/src/components/Deployments/index.tsx
@@ -54,7 +54,7 @@ const Deployments: FC<DeploymentsProps> = ({ deployments, environmentSlug, proje
               <div className="started">
                 {moment.utc(deployment.created).local().format('DD MMM YYYY, HH:mm:ss (Z)')}
               </div>
-              <div className={`status ${deployment.status}`}>
+              <div className={`status buildstep ${deployment.status}`}>
                 {deployment.status.charAt(0).toUpperCase() + deployment.status.slice(1)}
 
                 {!['complete', 'cancelled', 'failed'].includes(deployment.status) && deployment.buildStep && (

--- a/src/components/DeploymentsByFilter/StyledDeploymentsByFilter.js
+++ b/src/components/DeploymentsByFilter/StyledDeploymentsByFilter.js
@@ -156,7 +156,10 @@ export const DeploymentsDataTable = styled.div`
       border-bottom-left-radius: 3px;
       border-bottom-right-radius: 3px;
     }
-
+    .buildstep{
+      display:flex;
+      flex-direction:column;
+    }
     .status {
       @media ${bp.smallOnly} {
         background: none;

--- a/src/components/DeploymentsByFilter/index.js
+++ b/src/components/DeploymentsByFilter/index.js
@@ -198,7 +198,7 @@ const DeploymentsByFilter = ({ deployments }) => {
                 <div className="started">
                   {moment.utc(deployment.created).local().format('DD MMM YYYY, HH:mm:ss (Z)')}
                 </div>
-                <div className={`status ${deployment.status}`}>
+                <div className={`status buildstep ${deployment.status}`}>
                   {deployment.status.charAt(0).toUpperCase() + deployment.status.slice(1)}
 
                   {!['complete', 'cancelled', 'failed'].includes(deployment.status) && deployment.buildStep && (


### PR DESCRIPTION
This PR moves the build step status text into a new line
![image](https://github.com/uselagoon/lagoon-ui/assets/4373945/f3e87338-e5c0-44cd-a68c-a09ea1f8267a)
![image](https://github.com/uselagoon/lagoon-ui/assets/4373945/73afc6b0-bc18-4efd-80a9-82c1daba3d87)
![image](https://github.com/uselagoon/lagoon-ui/assets/4373945/98502c15-22cf-4852-8bc8-0f926f47b06d)


closes #200 