### PR TITLE
Enables parsed logs for Tasks

### DIFF
--- a/src/components/LogViewer/index.js
+++ b/src/components/LogViewer/index.js
@@ -4,12 +4,12 @@ import LogAccordion from 'components/LogViewer/LogAccordion';
 
 import { StyledLogs } from './StyledLogViewer';
 
-const LogViewer = ({ logs, status = 'NA', checkedParseState, changeState, forceLastSectionOpen = true }) => (
+const LogViewer = ({ logs, status = 'NA', checkedParseState, changeState, forceLastSectionOpen = true, logsTarget = "Deployments" }) => (
   <React.Fragment>
     <StyledLogs className="logs">
       {logs !== null ? (
         checkedParseState ? (
-          <div className="log-viewer">{logPreprocessor(logs, status, forceLastSectionOpen)}</div>
+          <div className="log-viewer">{logPreprocessor(logs, status, forceLastSectionOpen, logsTarget)}</div>
         ) : (
           <div className="log-viewer with-padding">{logs}</div>
         )
@@ -37,13 +37,13 @@ const isLogStateBad = status => {
  * @param {*} status a status for the build - if not complete, we open the very last item
  * @returns
  */
-const logPreprocessor = (logs, status, forceLastSectionOpen = true) => {
+const logPreprocessor = (logs, status, forceLastSectionOpen = true, logsTarget) => {
   let ret = null;
   let statusBad = isLogStateBad(status);
   let openLastSection = forceLastSectionOpen || shouldLastSectionBeOpen(status);
 
   try {
-    let tokens = logPreprocessorTokenize(logs);
+    let tokens = logPreprocessorTokenize(logs, logsTarget);
     let sectionMetadata = logPreprocessorExtractSectionEndDetails(logs);
     let AST = logPreprocessorProcessParse(tokens, sectionMetadata);
     return logPreprocessorProcessASTToReact(AST, openLastSection, statusBad);
@@ -183,12 +183,11 @@ const logPreprocessorExtractSectionEndDetails = logs => {
   return ret;
 };
 
-const logPreprocessorTokenize = logs => {
+const logPreprocessorTokenize = (logs, logsTarget) => {
   // tokenize
   const regexp =
     /##############################################\n(BEGIN) (.+)\n##############################################/;
-  const beginningSectionDefaultDetails = 'Build Setup';
-
+  const beginningSectionDefaultDetails = logsTarget === "Deployments" ? 'Build Setup' : 'Task Setup';
   // The regex above will split the logs into three separate token types
   // 1. standard blocks of text
   // 2. markers for section starts containing "SECTION" only

--- a/src/components/Task/index.tsx
+++ b/src/components/Task/index.tsx
@@ -79,7 +79,7 @@ const Task: FC<TaskProps> = ({ task, projectId, environmentId }) => {
           </div>
         )}
       </div>
-      <LogViewer logs={task.logs} status={task.status} changeState={null} checkedParseState={true} forceLastSectionOpen={true} />
+      <LogViewer logs={task.logs} status={task.status} changeState={null} checkedParseState={true} forceLastSectionOpen={true} logsTarget={"tasks"} />
     </StyledTask>
   );
 };

--- a/src/components/Task/index.tsx
+++ b/src/components/Task/index.tsx
@@ -79,7 +79,7 @@ const Task: FC<TaskProps> = ({ task, projectId, environmentId }) => {
           </div>
         )}
       </div>
-      <LogViewer logs={task.logs} status={task.status} changeState={null} checkedParseState={null} />
+      <LogViewer logs={task.logs} status={task.status} changeState={null} checkedParseState={true} forceLastSectionOpen={true} />
     </StyledTask>
   );
 };


### PR DESCRIPTION
Enables parsed logging for Tasks, displaying the logs in accordion format as Deployments do.

![image](https://github.com/uselagoon/lagoon-ui/assets/40746380/24200c28-7235-4af9-b317-9e616e41e73b)
