### PR TITLE
fix: use email address in profile, not username

### DIFF
--- a/src/lib/withKeycloak.js
+++ b/src/lib/withKeycloak.js
@@ -52,7 +52,7 @@ export default (App, initialAuth) => {
           provider: 'keycloak',
           providerData: keycloak,
           user: {
-            username: keycloak.tokenParsed ? keycloak.tokenParsed.preferred_username : 'unauthenticated',
+            username: keycloak.tokenParsed ? keycloak.tokenParsed.email : 'unauthenticated',
           },
         },
       });


### PR DESCRIPTION
Lagoon currently displays the `username` of the keycloak user in the UI, this field is unchangeable by the user, and Lagoon does not use this field when interacting with users, it uses the `email` field see https://github.com/uselagoon/lagoon/issues/3656

This changes the field to display the email address from the token rather than the preferred_username. This should only be merged if https://github.com/uselagoon/lagoon/issues/3657 is also merged which fixes all the underlying resolver code to use email instead of the username.