### PR TITLE
fix: add keycloak migrations container to minimal

### DIFF
--- a/test/docker-compose.yaml
+++ b/test/docker-compose.yaml
@@ -18,6 +18,16 @@ services:
     depends_on:
       - api-db
       - keycloak
+  api-lagoon-migrations:
+    image: testlagoon/api:main
+    command: sh -c "./node_modules/.bin/tsc && node -r dotenv-extended/config dist/migrations/lagoon/migration.js"
+    environment:
+      - KEYCLOAK_URL=http://172.17.0.1:38088
+    depends_on:
+      api-init:
+        condition: service_completed_successfully # don't start the lagoon migrations until the db migrations is completed
+      keycloak:
+        condition: service_started
   api:
     image: testlagoon/api:main
     ports:
@@ -35,7 +45,7 @@ services:
       - S3_BAAS_SECRET_ACCESS_KEY=minio123
       - CONSOLE_LOGGING_LEVEL=trace
     depends_on:
-      - api-init
+      - api-lagoon-migrations
   api-redis:
     image: testlagoon/api-redis:main
   keycloak:

--- a/test/docker-compose.yaml
+++ b/test/docker-compose.yaml
@@ -4,22 +4,22 @@ name: lagoon-minimal
 
 services:
   api-db:
-    image: testlagoon/api-db:pr-3684
+    image: testlagoon/api-db:main
     networks:
       - default
   broker:
-    image: testlagoon/broker:pr-3684
+    image: testlagoon/broker:main
     restart: on-failure
     networks:
       - default
   api-init:
-    image: testlagoon/api:pr-3684
+    image: testlagoon/api:main
     command: ./node_modules/.bin/knex migrate:latest --cwd /app/services/api/database
     depends_on:
       - api-db
       - keycloak
   api-lagoon-migrations:
-    image: testlagoon/api:pr-3684
+    image: testlagoon/api:main
     command: sh -c "./node_modules/.bin/tsc && node -r dotenv-extended/config dist/migrations/lagoon/migration.js"
     environment:
       - KEYCLOAK_URL=http://172.17.0.1:38088
@@ -29,7 +29,7 @@ services:
       keycloak:
         condition: service_started
   api:
-    image: testlagoon/api:pr-3684
+    image: testlagoon/api:main
     ports:
       - '33000:3000'
     networks:
@@ -47,9 +47,9 @@ services:
     depends_on:
       - api-lagoon-migrations
   api-redis:
-    image: testlagoon/api-redis:pr-3684
+    image: testlagoon/api-redis:main
   keycloak:
-    image: testlagoon/keycloak:pr-3684
+    image: testlagoon/keycloak:main
     depends_on:
       - keycloak-db
     ports:
@@ -59,7 +59,7 @@ services:
     environment:
      - KEYCLOAK_FRONTEND_URL=http://0.0.0.0:38088/auth
   keycloak-db:
-    image: testlagoon/keycloak-db:pr-3684
+    image: testlagoon/keycloak-db:main
   local-minio:
     image: minio/minio
     entrypoint: sh
@@ -71,7 +71,7 @@ services:
       - MINIO_ROOT_USER=minio
       - MINIO_ROOT_PASSWORD=minio123
   local-api-data-watcher-pusher:
-    image: testlagoon/local-api-data-watcher-pusher:pr-3684
+    image: testlagoon/local-api-data-watcher-pusher:main
     depends_on:
       - api
     command: ["bash", "-c", "

--- a/test/docker-compose.yaml
+++ b/test/docker-compose.yaml
@@ -4,22 +4,22 @@ name: lagoon-minimal
 
 services:
   api-db:
-    image: testlagoon/api-db:main
+    image: testlagoon/api-db:pr-3684
     networks:
       - default
   broker:
-    image: testlagoon/broker-single:main
+    image: testlagoon/broker:pr-3684
     restart: on-failure
     networks:
       - default
   api-init:
-    image: testlagoon/api:main
+    image: testlagoon/api:pr-3684
     command: ./node_modules/.bin/knex migrate:latest --cwd /app/services/api/database
     depends_on:
       - api-db
       - keycloak
   api-lagoon-migrations:
-    image: testlagoon/api:main
+    image: testlagoon/api:pr-3684
     command: sh -c "./node_modules/.bin/tsc && node -r dotenv-extended/config dist/migrations/lagoon/migration.js"
     environment:
       - KEYCLOAK_URL=http://172.17.0.1:38088
@@ -29,7 +29,7 @@ services:
       keycloak:
         condition: service_started
   api:
-    image: testlagoon/api:main
+    image: testlagoon/api:pr-3684
     ports:
       - '33000:3000'
     networks:
@@ -47,9 +47,9 @@ services:
     depends_on:
       - api-lagoon-migrations
   api-redis:
-    image: testlagoon/api-redis:main
+    image: testlagoon/api-redis:pr-3684
   keycloak:
-    image: testlagoon/keycloak:main
+    image: testlagoon/keycloak:pr-3684
     depends_on:
       - keycloak-db
     ports:
@@ -59,7 +59,7 @@ services:
     environment:
      - KEYCLOAK_FRONTEND_URL=http://0.0.0.0:38088/auth
   keycloak-db:
-    image: testlagoon/keycloak-db:main
+    image: testlagoon/keycloak-db:pr-3684
   local-minio:
     image: minio/minio
     entrypoint: sh
@@ -71,7 +71,7 @@ services:
       - MINIO_ROOT_USER=minio
       - MINIO_ROOT_PASSWORD=minio123
   local-api-data-watcher-pusher:
-    image: testlagoon/local-api-data-watcher-pusher:main
+    image: testlagoon/local-api-data-watcher-pusher:pr-3684
     depends_on:
       - api
     command: ["bash", "-c", "


### PR DESCRIPTION
With the upcoming addition of keycloak migrations to lagoon 2.18, this PR adds that step into the lagoon-minimal setup.