### PR TITLE
Order environments by name

### DIFF
--- a/src/pages/project.js
+++ b/src/pages/project.js
@@ -80,7 +80,7 @@ export const PageProject = ({ router }) => {
   }
   // Sort alphabetically by environmentType and then deployType
   const environments = R.sortWith(
-    [R.descend(R.prop('environmentType')), R.ascend(R.prop('deployType'))],
+    [R.descend(R.prop('environmentType')), R.ascend(R.prop('deployType')), R.ascend(R.prop('name'))],
     project.environments
   );
   const environmentCount = environments.length;

--- a/src/pages/project.js
+++ b/src/pages/project.js
@@ -80,7 +80,11 @@ export const PageProject = ({ router }) => {
   }
   // Sort alphabetically by environmentType and then deployType
   const environments = R.sortWith(
-    [R.descend(R.prop('environmentType')), R.ascend(R.prop('deployType')), R.ascend(R.prop('name'))],
+    [
+      R.descend(R.prop('environmentType')),
+      R.ascend(R.prop('deployType')),
+      R.ascend(env => (env.deployType === 'branch' ? env.name : null)),
+    ],
     project.environments
   );
   const environmentCount = environments.length;


### PR DESCRIPTION
closes #232 by adding an alpha sort within the deployType

This applies two sorts - an alpha sort on branches, and a id-based sort on PR envs - this will help them maintain their numerical order as below
![image](https://github.com/uselagoon/lagoon-ui/assets/4373945/a66b57e3-30e0-4505-a950-970749a1a6ee)
