### PR TITLE
Fix: Fixes variable deletion btn & updates the delete modal btn text to confirm successful deletion

### DIFF
--- a/src/components/DeleteVariable/index.js
+++ b/src/components/DeleteVariable/index.js
@@ -8,6 +8,7 @@ import Modal from 'components/Modal';
 
 import DeleteEnvVariableMutation from '../../lib/mutation/deleteEnvVariableByName';
 import { DeleteVariableButton, DeleteVariableModal } from './StyledDeleteVariable';
+import {LoadingOutlined} from "@ant-design/icons";
 
 /**
  * Deletes a Variable.
@@ -26,19 +27,34 @@ export const DeleteVariable = ({
   open,
   openModal,
   closeModal,
+  envValues,
+  prjEnvValues,
+  loading,
+  valueState,
 }) => {
+  const handlePermissionCheck = () => {
+    let waitForGQL = setTimeout(() => {
+      openModal();
+    }, [1000]);
+    if (prjEnvValues || envValues) {
+      clearTimeout(waitForGQL);
+      openModal();
+    }
+  };
+
   return (
     <React.Fragment>
       <DeleteVariableButton>
-        {icon ? (
-          <Button variant="red" icon={icon} action={openModal}>
-            Delete
-          </Button>
-        ) : (
-          <Button variant="red" action={openModal}>
-            Delete
-          </Button>
-        )}
+        {
+          loading && valueState ? (
+            <Button variant="red" action={openModal}>
+              <LoadingOutlined />
+            </Button>
+          ) : (
+            <Button variant="red" icon={icon} action={handlePermissionCheck}>
+            </Button>
+          )
+        }
       </DeleteVariableButton>
       <Modal isOpen={open} onRequestClose={closeModal} contentLabel={`Confirm`} variant={'large'}>
         <DeleteVariableModal>
@@ -82,7 +98,7 @@ export const DeleteVariable = ({
                     className="btn-danger"
                     onClick={deleteEnvVariableByNameHandler}
                   >
-                    {loading ? 'Deleting...' : 'Delete'}
+                    {loading ? 'Deleting...' : data ? 'Success' : 'Delete'}
                   </ButtonBootstrap>
                 );
               }}

--- a/src/components/DeleteVariable/index.js
+++ b/src/components/DeleteVariable/index.js
@@ -2,13 +2,13 @@ import React, { useEffect, useState } from 'react';
 import { Mutation } from 'react-apollo';
 import ButtonBootstrap from 'react-bootstrap/Button';
 
+import { LoadingOutlined } from '@ant-design/icons';
 import withLogic from 'components/AddVariable/logic';
 import Button from 'components/Button';
 import Modal from 'components/Modal';
 
 import DeleteEnvVariableMutation from '../../lib/mutation/deleteEnvVariableByName';
 import { DeleteVariableButton, DeleteVariableModal } from './StyledDeleteVariable';
-import {LoadingOutlined} from "@ant-design/icons";
 
 /**
  * Deletes a Variable.
@@ -45,16 +45,13 @@ export const DeleteVariable = ({
   return (
     <React.Fragment>
       <DeleteVariableButton>
-        {
-          loading && valueState ? (
-            <Button variant="red" action={openModal}>
-              <LoadingOutlined />
-            </Button>
-          ) : (
-            <Button variant="red" icon={icon} action={handlePermissionCheck}>
-            </Button>
-          )
-        }
+        {loading && valueState ? (
+          <Button variant="red" action={openModal}>
+            <LoadingOutlined />
+          </Button>
+        ) : (
+          <Button variant="red" icon={icon} action={handlePermissionCheck}></Button>
+        )}
       </DeleteVariableButton>
       <Modal isOpen={open} onRequestClose={closeModal} contentLabel={`Confirm`} variant={'large'}>
         <DeleteVariableModal>

--- a/src/components/EnvironmentVariables/StyledEnvironmentVariables.tsx
+++ b/src/components/EnvironmentVariables/StyledEnvironmentVariables.tsx
@@ -119,6 +119,12 @@ export const StyledEnvironmentVariableDetails = styled.div`
       height: 38px;
     }
 
+    @media ${bp.xs_smallUp} {
+      .show-value-btn {
+        min-width: 116px;
+      }
+    }
+
     button {
       margin-right: 4px;
     }

--- a/src/components/EnvironmentVariables/index.js
+++ b/src/components/EnvironmentVariables/index.js
@@ -133,10 +133,13 @@ const EnvironmentVariables = ({ environment, onVariableAdded }) => {
     setUpdateVarScope(rowScope);
   };
 
-  const permissionCheck = action => {
+  const permissionCheck = (action, index = null) => {
     getEnvVarValues();
     setOpenEnvVars(false);
     setAction(action);
+    if (action === "delete") {
+      valuesShow(index);
+    }
   };
 
   const renderEnvValue = (envVar, index) => {
@@ -164,10 +167,6 @@ const EnvironmentVariables = ({ environment, onVariableAdded }) => {
   };
 
   const renderEnvValues = (envVar, index) => {
-    if (envLoading) {
-      return <div className="loader"></div>;
-    }
-
     if (envVar.value !== undefined) {
       return (
         <Collapse in={openEnvVars}>
@@ -194,10 +193,6 @@ const EnvironmentVariables = ({ environment, onVariableAdded }) => {
   };
 
   const renderPrjValues = (projEnvVar, index) => {
-    if (prjLoading) {
-      return <div className="loader"></div>;
-    }
-
     if (projEnvVar.value !== undefined) {
       return (
         <Collapse in={openPrjVars}>
@@ -252,7 +247,7 @@ const EnvironmentVariables = ({ environment, onVariableAdded }) => {
                   refresh={onVariableAdded}
                   setEnvironmentErrorAlert={setEnvironmentErrorAlert}
                   action="add"
-                  loading={prjLoading && action === 'add'}
+                  loading={envLoading && action === 'add'}
                   envValues={envValues}
                 />
               )}
@@ -262,9 +257,10 @@ const EnvironmentVariables = ({ environment, onVariableAdded }) => {
                 onClick={() => showVarValue()}
                 aria-controls="example-collapse-text"
                 data-cy="hideShowValues"
-                aria-expanded={openPrjVars}
+                aria-expanded={openEnvVars}
+                className="show-value-btn"
               >
-                {!openEnvVars ? 'Show values' : 'Hide values'}
+                {!openEnvVars ? 'Show values' : envLoading ? <LoadingOutlined /> : 'Hide values'}
               </Button>
             )}
           </div>
@@ -281,29 +277,32 @@ const EnvironmentVariables = ({ environment, onVariableAdded }) => {
         {displayVars.length > 0 && (
           <div className="field-wrapper env-vars">
             <StyledVariableTable>
-              <div className={openEnvVars ? 'values-present table-header' : 'table-header'}>
+              <div className={!envLoading && openEnvVars ? 'values-present table-header' : 'table-header'}>
                 <div className="name">
                   <label>Name</label>
                 </div>
                 <div className="scope">
                   <label>Scope</label>
                 </div>
-                <Collapse in={openEnvVars}>
-                  <div className="value">
-                    <label>Value</label>
-                  </div>
-                </Collapse>
+                {!envLoading &&(
+                    <Collapse in={openEnvVars}>
+                      <div className="value">
+                        <label>Value</label>
+                      </div>
+                    </Collapse>
+                )}
               </div>
               <div className="data-table" data-cy="environment-table">
                 {displayVars.map((envVar, index) => {
                   return (
                     <Fragment key={index}>
-                      <div className={openEnvVars ? 'values-present data-row' : 'data-row'} data-cy="environment-row">
+                      <div className={!envLoading && openEnvVars ? 'values-present data-row' : 'data-row'} data-cy="environment-row">
                         <div className="varName">{envVar.name}</div>
                         <div className="varScope">{envVar.scope}</div>
                         {renderEnvValues(envVar, index)}
                         <div className="varActions">
                           <VariableActions>
+                            { !envLoading && (
                             <Collapse in={openEnvVars}>
                               <div className="varUpdate">
                                 <Tooltip overlayClassName="componentTooltip" title="Update Variable" placement="bottom">
@@ -327,18 +326,18 @@ const EnvironmentVariables = ({ environment, onVariableAdded }) => {
                                 </Tooltip>
                               </div>
                             </Collapse>
+                            )}
                             <div className="varDelete">
                               <Tooltip overlayClassName="componentTooltip" title="Delete Variable" placement="bottom">
                                 <Button onClick={() => permissionCheck('delete', index)} style={{ all: 'unset' }}>
-                                  {envLoading && action === 'delete' ? (
+                                  {environmentErrorAlert ? (
                                     <DeleteVariableButton>
                                       <Btn
                                         index={index}
                                         variant="red"
-                                        icon={!valueState[index] ? 'bin' : ''}
+                                        icon="bin"
                                         className="delete-btn"
                                       >
-                                        {valueState[index] ? <LoadingOutlined /> : 'Delete'}
                                       </Btn>
                                     </DeleteVariableButton>
                                   ) : (
@@ -349,6 +348,9 @@ const EnvironmentVariables = ({ environment, onVariableAdded }) => {
                                       varEnvironment={environment.name}
                                       icon="bin"
                                       refresh={onVariableAdded}
+                                      envValues={envValues}
+                                      loading={envLoading && action === 'delete'}
+                                      valueState={valueState[index]}
                                     />
                                   )}
                                 </Button>
@@ -390,8 +392,9 @@ const EnvironmentVariables = ({ environment, onVariableAdded }) => {
                 onClick={() => showPrjVarValue()}
                 aria-controls="example-collapse-text"
                 aria-expanded={openPrjVars}
+                className="show-value-btn"
               >
-                {!openPrjVars ? 'Show values' : 'Hide values'}
+                {!openPrjVars ? 'Show values' : prjLoading ? <LoadingOutlined /> : 'Hide values'}
               </Button>
             )}
           </div>
@@ -408,24 +411,26 @@ const EnvironmentVariables = ({ environment, onVariableAdded }) => {
         {displayProjectVars.length > 0 && (
           <div className="field-wrapper env-vars">
             <StyledProjectVariableTable>
-              <div className={openPrjVars ? 'values-present table-header' : 'table-header'}>
+              <div className={!prjLoading && openPrjVars ? 'values-present table-header' : 'table-header'}>
                 <div className="name">
                   <label>Name</label>
                 </div>
                 <div className="scope">
                   <label>Scope</label>
                 </div>
-                <Collapse in={openPrjVars}>
-                  <div className="value">
-                    <label>Value</label>
-                  </div>
-                </Collapse>
+                {!prjLoading && (
+                  <Collapse in={openPrjVars}>
+                    <div className="value">
+                      <label>Value</label>
+                    </div>
+                  </Collapse>
+                )}
               </div>
               <div className="data-table" data-cy="environment-table">
                 {displayProjectVars.map((projEnvVar, index) => {
                   return (
                     <Fragment key={index}>
-                      <div className={openPrjVars ? 'values-present data-row' : 'data-row'} data-cy="environment-row">
+                      <div className={!prjLoading && openPrjVars ? 'values-present data-row' : 'data-row'} data-cy="environment-row">
                         <div className="varName">{projEnvVar.name}</div>
                         <div className="varScope">{projEnvVar.scope}</div>
                         {renderPrjValues(projEnvVar, index)}

--- a/src/components/EnvironmentVariables/index.js
+++ b/src/components/EnvironmentVariables/index.js
@@ -137,7 +137,7 @@ const EnvironmentVariables = ({ environment, onVariableAdded }) => {
     getEnvVarValues();
     setOpenEnvVars(false);
     setAction(action);
-    if (action === "delete") {
+    if (action === 'delete') {
       valuesShow(index);
     }
   };
@@ -284,61 +284,62 @@ const EnvironmentVariables = ({ environment, onVariableAdded }) => {
                 <div className="scope">
                   <label>Scope</label>
                 </div>
-                {!envLoading &&(
-                    <Collapse in={openEnvVars}>
-                      <div className="value">
-                        <label>Value</label>
-                      </div>
-                    </Collapse>
+                {!envLoading && (
+                  <Collapse in={openEnvVars}>
+                    <div className="value">
+                      <label>Value</label>
+                    </div>
+                  </Collapse>
                 )}
               </div>
               <div className="data-table" data-cy="environment-table">
                 {displayVars.map((envVar, index) => {
                   return (
                     <Fragment key={index}>
-                      <div className={!envLoading && openEnvVars ? 'values-present data-row' : 'data-row'} data-cy="environment-row">
+                      <div
+                        className={!envLoading && openEnvVars ? 'values-present data-row' : 'data-row'}
+                        data-cy="environment-row"
+                      >
                         <div className="varName">{envVar.name}</div>
                         <div className="varScope">{envVar.scope}</div>
                         {renderEnvValues(envVar, index)}
                         <div className="varActions">
                           <VariableActions>
-                            { !envLoading && (
-                            <Collapse in={openEnvVars}>
-                              <div className="varUpdate">
-                                <Tooltip overlayClassName="componentTooltip" title="Update Variable" placement="bottom">
-                                  <Button
-                                    onClick={() => setUpdateValue(envVar.value, envVar.name, envVar.scope)}
-                                    style={{ all: 'unset' }}
+                            {!envLoading && (
+                              <Collapse in={openEnvVars}>
+                                <div className="varUpdate">
+                                  <Tooltip
+                                    overlayClassName="componentTooltip"
+                                    title="Update Variable"
+                                    placement="bottom"
                                   >
-                                    <AddVariable
-                                      varProject={environment.project.name}
-                                      varEnvironment={environment.name}
-                                      varValues={displayVars}
-                                      varTarget="Environment"
-                                      varName={updateVarName}
-                                      varValue={updateVarValue}
-                                      varScope={updateVarScope}
-                                      refresh={onVariableAdded}
-                                      icon="edit"
-                                      action="edit"
-                                    />
-                                  </Button>
-                                </Tooltip>
-                              </div>
-                            </Collapse>
+                                    <Button
+                                      onClick={() => setUpdateValue(envVar.value, envVar.name, envVar.scope)}
+                                      style={{ all: 'unset' }}
+                                    >
+                                      <AddVariable
+                                        varProject={environment.project.name}
+                                        varEnvironment={environment.name}
+                                        varValues={displayVars}
+                                        varTarget="Environment"
+                                        varName={updateVarName}
+                                        varValue={updateVarValue}
+                                        varScope={updateVarScope}
+                                        refresh={onVariableAdded}
+                                        icon="edit"
+                                        action="edit"
+                                      />
+                                    </Button>
+                                  </Tooltip>
+                                </div>
+                              </Collapse>
                             )}
                             <div className="varDelete">
                               <Tooltip overlayClassName="componentTooltip" title="Delete Variable" placement="bottom">
                                 <Button onClick={() => permissionCheck('delete', index)} style={{ all: 'unset' }}>
                                   {environmentErrorAlert ? (
                                     <DeleteVariableButton>
-                                      <Btn
-                                        index={index}
-                                        variant="red"
-                                        icon="bin"
-                                        className="delete-btn"
-                                      >
-                                      </Btn>
+                                      <Btn index={index} variant="red" icon="bin" className="delete-btn"></Btn>
                                     </DeleteVariableButton>
                                   ) : (
                                     <DeleteVariable
@@ -430,7 +431,10 @@ const EnvironmentVariables = ({ environment, onVariableAdded }) => {
                 {displayProjectVars.map((projEnvVar, index) => {
                   return (
                     <Fragment key={index}>
-                      <div className={!prjLoading && openPrjVars ? 'values-present data-row' : 'data-row'} data-cy="environment-row">
+                      <div
+                        className={!prjLoading && openPrjVars ? 'values-present data-row' : 'data-row'}
+                        data-cy="environment-row"
+                      >
                         <div className="varName">{projEnvVar.name}</div>
                         <div className="varScope">{projEnvVar.scope}</div>
                         {renderPrjValues(projEnvVar, index)}

--- a/src/components/ProjectVariables/StyledProjectVariables.tsx
+++ b/src/components/ProjectVariables/StyledProjectVariables.tsx
@@ -113,6 +113,12 @@ export const StyledProjectVariablesDetails = styled.div`
       height: 38px;
     }
 
+    @media ${bp.xs_smallUp} {
+      .show-value-btn {
+        min-width: 116px;
+      }
+    }
+
     button {
       margin-right: 4px;
     }

--- a/src/components/ProjectVariables/index.js
+++ b/src/components/ProjectVariables/index.js
@@ -93,7 +93,7 @@ const ProjectVariables = ({ project, onVariableAdded }) => {
     getPrjEnvVarValues();
     setOpenPrjVars(false);
     setAction(action);
-    if (action === "delete") {
+    if (action === 'delete') {
       valuesShow(index);
     }
   };
@@ -213,18 +213,27 @@ const ProjectVariables = ({ project, onVariableAdded }) => {
                 {displayVars.map((projEnvVar, index) => {
                   return (
                     <Fragment key={index}>
-                      <div className={!prjLoading && openPrjVars ? 'values-present data-row' : 'data-row'} data-cy="environment-row">
+                      <div
+                        className={!prjLoading && openPrjVars ? 'values-present data-row' : 'data-row'}
+                        data-cy="environment-row"
+                      >
                         <div className="varName">{projEnvVar.name}</div>
                         <div className="varScope">{projEnvVar.scope}</div>
                         {renderValues(projEnvVar, index)}
                         <div className="varActions">
                           <VariableActions>
-                            { !prjLoading && (
+                            {!prjLoading && (
                               <Collapse in={openPrjVars}>
                                 <div className="varUpdate">
-                                  <Tooltip overlayClassName="componentTooltip" title="Update Variable" placement="bottom">
+                                  <Tooltip
+                                    overlayClassName="componentTooltip"
+                                    title="Update Variable"
+                                    placement="bottom"
+                                  >
                                     <Button
-                                      onClick={() => setUpdateValue(projEnvVar.value, projEnvVar.name, projEnvVar.scope)}
+                                      onClick={() =>
+                                        setUpdateValue(projEnvVar.value, projEnvVar.name, projEnvVar.scope)
+                                      }
                                       style={{ all: 'unset' }}
                                     >
                                       <AddVariable
@@ -248,13 +257,7 @@ const ProjectVariables = ({ project, onVariableAdded }) => {
                                 <Button onClick={() => permissionCheck('delete', index)} style={{ all: 'unset' }}>
                                   {projectErrorAlert ? (
                                     <DeleteVariableButton>
-                                      <Btn
-                                        index={index}
-                                        variant="red"
-                                        icon="bin"
-                                        className="delete-btn"
-                                      >
-                                      </Btn>
+                                      <Btn index={index} variant="red" icon="bin" className="delete-btn"></Btn>
                                     </DeleteVariableButton>
                                   ) : (
                                     <DeleteVariable

--- a/src/components/ProjectVariables/index.js
+++ b/src/components/ProjectVariables/index.js
@@ -89,10 +89,13 @@ const ProjectVariables = ({ project, onVariableAdded }) => {
     setUpdateVarScope(rowScope);
   };
 
-  const permissionCheck = action => {
+  const permissionCheck = (action, index = null) => {
     getPrjEnvVarValues();
     setOpenPrjVars(false);
     setAction(action);
+    if (action === "delete") {
+      valuesShow(index);
+    }
   };
 
   const renderValue = (projEnvVar, index) => {
@@ -108,10 +111,6 @@ const ProjectVariables = ({ project, onVariableAdded }) => {
   };
 
   const renderValues = (projEnvVar, index) => {
-    if (prjLoading) {
-      return <div className="loader"></div>;
-    }
-
     if (projEnvVar.value !== undefined) {
       return (
         <Collapse in={openPrjVars}>
@@ -176,8 +175,9 @@ const ProjectVariables = ({ project, onVariableAdded }) => {
                 aria-controls="example-collapse-text"
                 aria-expanded={openPrjVars}
                 data-cy="hideShowValues"
+                className="show-value-btn"
               >
-                {!openPrjVars ? 'Show values' : 'Hide values'}
+                {!openPrjVars ? 'Show values' : prjLoading ? <LoadingOutlined /> : 'Hide values'}
               </Button>
             )}
           </div>
@@ -194,63 +194,66 @@ const ProjectVariables = ({ project, onVariableAdded }) => {
         {displayVars.length > 0 && (
           <div className="field-wrapper env-vars">
             <StyledProjectVariableTable>
-              <div className={openPrjVars ? 'values-present table-header' : 'table-header'}>
+              <div className={!prjLoading && openPrjVars ? 'values-present table-header' : 'table-header'}>
                 <div className="name">
                   <label>Name</label>
                 </div>
                 <div className="scope">
                   <label>Scope</label>
                 </div>
-                <Collapse in={openPrjVars}>
-                  <div className="value">
-                    <label>Value</label>
-                  </div>
-                </Collapse>
+                {!prjLoading && (
+                  <Collapse in={openPrjVars}>
+                    <div className="value">
+                      <label>Value</label>
+                    </div>
+                  </Collapse>
+                )}
               </div>
               <div className="data-table" data-cy="environment-table">
                 {displayVars.map((projEnvVar, index) => {
                   return (
                     <Fragment key={index}>
-                      <div className={openPrjVars ? 'values-present data-row' : 'data-row'} data-cy="environment-row">
+                      <div className={!prjLoading && openPrjVars ? 'values-present data-row' : 'data-row'} data-cy="environment-row">
                         <div className="varName">{projEnvVar.name}</div>
                         <div className="varScope">{projEnvVar.scope}</div>
                         {renderValues(projEnvVar, index)}
                         <div className="varActions">
                           <VariableActions>
-                            <Collapse in={openPrjVars}>
-                              <div className="varUpdate">
-                                <Tooltip overlayClassName="componentTooltip" title="Update Variable" placement="bottom">
-                                  <Button
-                                    onClick={() => setUpdateValue(projEnvVar.value, projEnvVar.name, projEnvVar.scope)}
-                                    style={{ all: 'unset' }}
-                                  >
-                                    <AddVariable
-                                      varProject={project.name}
-                                      varValues={displayVars}
-                                      varTarget="Project"
-                                      varName={updateVarName}
-                                      varValue={updateVarValue}
-                                      varScope={updateVarScope}
-                                      refresh={onVariableAdded}
-                                      icon="edit"
-                                      action="edit"
-                                    />
-                                  </Button>
-                                </Tooltip>
-                              </div>
-                            </Collapse>
+                            { !prjLoading && (
+                              <Collapse in={openPrjVars}>
+                                <div className="varUpdate">
+                                  <Tooltip overlayClassName="componentTooltip" title="Update Variable" placement="bottom">
+                                    <Button
+                                      onClick={() => setUpdateValue(projEnvVar.value, projEnvVar.name, projEnvVar.scope)}
+                                      style={{ all: 'unset' }}
+                                    >
+                                      <AddVariable
+                                        varProject={project.name}
+                                        varValues={displayVars}
+                                        varTarget="Project"
+                                        varName={updateVarName}
+                                        varValue={updateVarValue}
+                                        varScope={updateVarScope}
+                                        refresh={onVariableAdded}
+                                        icon="edit"
+                                        action="edit"
+                                      />
+                                    </Button>
+                                  </Tooltip>
+                                </div>
+                              </Collapse>
+                            )}
                             <div className="varDelete" data-cy="varDelete">
                               <Tooltip overlayClassName="componentTooltip" title="Delete Variable" placement="bottom">
                                 <Button onClick={() => permissionCheck('delete', index)} style={{ all: 'unset' }}>
-                                  {prjLoading && action === 'delete' ? (
+                                  {projectErrorAlert ? (
                                     <DeleteVariableButton>
                                       <Btn
                                         index={index}
                                         variant="red"
-                                        icon={!valueState[index] ? 'bin' : ''}
+                                        icon="bin"
                                         className="delete-btn"
                                       >
-                                        {valueState[index] ? <LoadingOutlined /> : 'Delete'}
                                       </Btn>
                                     </DeleteVariableButton>
                                   ) : (
@@ -260,6 +263,9 @@ const ProjectVariables = ({ project, onVariableAdded }) => {
                                       varProject={project.name}
                                       icon="bin"
                                       refresh={onVariableAdded}
+                                      envValues={prjEnvValues}
+                                      loading={prjLoading && action === 'delete'}
+                                      valueState={valueState[index]}
                                     />
                                   )}
                                 </Button>


### PR DESCRIPTION
Currently when clicking the delete icon for a variable a permission check is run but the delete modal is not opened, subsequent clicks open the modal. This updates the `DeleteVariable` component to hande the permission check and open the modal if permitted. 

This also updates the delete modal button text to show 'Success' on successful deletion to confirm the deletion has run successfully. Also cleans up the loading state for environment and project variable tabs.

closes https://github.com/uselagoon/lagoon-ui/issues/239, closes https://github.com/uselagoon/lagoon-ui/issues/240