### PR TITLE
Fix: Environment variables - allows multiline values & clears form data on close

### DIFF
--- a/src/components/AddVariable/StyledAddVariable.tsx
+++ b/src/components/AddVariable/StyledAddVariable.tsx
@@ -33,7 +33,7 @@ export const NewVariableModal = styled.div`
     font-family: 'source-code-pro', sans-serif;
     font-weight: bold;
   }
-  input {
+  input, textarea {
     margin-right: 10px;
     width: 100%;
   }

--- a/src/components/AddVariable/StyledAddVariable.tsx
+++ b/src/components/AddVariable/StyledAddVariable.tsx
@@ -33,7 +33,8 @@ export const NewVariableModal = styled.div`
     font-family: 'source-code-pro', sans-serif;
     font-weight: bold;
   }
-  input, textarea {
+  input,
+  textarea {
     margin-right: 10px;
     width: 100%;
   }

--- a/src/components/AddVariable/index.js
+++ b/src/components/AddVariable/index.js
@@ -145,16 +145,15 @@ export const AddVariable = ({
             />
           </div>
           <div className="var-modal">
-            <label htmlFor="varName">Value</label>
-            <input
+            <label htmlFor="varValue">Value</label>
+            <textarea
               data-cy="varValue"
               id="varValueId"
               name="varValue"
               className="addVarValueInput"
-              type="text"
               value={varValue ? updateValue : inputValue}
               onChange={varValue ? handleUpdateValue : setInputValue}
-            />
+            ></textarea>
           </div>
           <div className="form-input add-var-btn" data-cy="add-variable">
             <a href="#" className="hover-state" onClick={closeModal}>
@@ -230,8 +229,8 @@ export const AddVariable = ({
                             ? 'Update environment variable'
                             : 'Add environment variable'
                           : updateVar || varName
-                            ? 'Update project variable'
-                            : 'Add project variable'}
+                          ? 'Update project variable'
+                          : 'Add project variable'}
                       </ButtonBootstrap>
                     </Popconfirm>
                   );
@@ -248,8 +247,8 @@ export const AddVariable = ({
                           ? 'Update environment variable'
                           : 'Add environment variable'
                         : updateVar || varName
-                          ? 'Update project variable'
-                          : 'Add project variable'}
+                        ? 'Update project variable'
+                        : 'Add project variable'}
                     </ButtonBootstrap>
                   );
                 }

--- a/src/components/AddVariable/index.js
+++ b/src/components/AddVariable/index.js
@@ -229,8 +229,8 @@ export const AddVariable = ({
                             ? 'Update environment variable'
                             : 'Add environment variable'
                           : updateVar || varName
-                          ? 'Update project variable'
-                          : 'Add project variable'}
+                            ? 'Update project variable'
+                            : 'Add project variable'}
                       </ButtonBootstrap>
                     </Popconfirm>
                   );
@@ -247,8 +247,8 @@ export const AddVariable = ({
                           ? 'Update environment variable'
                           : 'Add environment variable'
                         : updateVar || varName
-                        ? 'Update project variable'
-                        : 'Add project variable'}
+                          ? 'Update project variable'
+                          : 'Add project variable'}
                     </ButtonBootstrap>
                   );
                 }

--- a/src/components/AddVariable/logic.js
+++ b/src/components/AddVariable/logic.js
@@ -18,7 +18,8 @@ const withInputHandlers = withHandlers({
       setInputName(event.target.value),
   setClear:
     ({ setInputValue, setInputName, setInputScope }) =>
-    () => [setInputValue(''), setInputName(''), setInputScope('')],
+    () =>
+      [setInputValue(''), setInputName(''), setInputScope('')],
 });
 
 const withModalState = withState('open', 'setOpen', false);
@@ -28,9 +29,11 @@ const withModalHandlers = withHandlers({
     () =>
       setOpen(true),
   closeModal:
-    ({ setOpen }) =>
-    () =>
-      setOpen(false),
+    ({ setOpen, setClear }) =>
+    () => {
+      setOpen(false);
+      setClear();
+    }
 });
 
 export default compose(

--- a/src/components/AddVariable/logic.js
+++ b/src/components/AddVariable/logic.js
@@ -18,8 +18,7 @@ const withInputHandlers = withHandlers({
       setInputName(event.target.value),
   setClear:
     ({ setInputValue, setInputName, setInputScope }) =>
-    () =>
-      [setInputValue(''), setInputName(''), setInputScope('')],
+    () => [setInputValue(''), setInputName(''), setInputScope('')],
 });
 
 const withModalState = withState('open', 'setOpen', false);
@@ -33,7 +32,7 @@ const withModalHandlers = withHandlers({
     () => {
       setOpen(false);
       setClear();
-    }
+    },
 });
 
 export default compose(

--- a/src/components/ViewVariableValue/StyledViewVariableValue.tsx
+++ b/src/components/ViewVariableValue/StyledViewVariableValue.tsx
@@ -34,6 +34,7 @@ export const StyledViewVariableValueModal = styled.div`
     .col-3 {
       width: fit-content;
       line-break: anywhere;
+      white-space: break-spaces;
     }
     a.external-link {
       color: ${color.brightBlue};


### PR DESCRIPTION
Updates the add environment variable form to allow multiline values to accomodate certificates, SSH keys etc.
Also clears data on the add environment variable form when closing the modal.

closes https://github.com/uselagoon/lagoon-ui/issues/257 https://github.com/uselagoon/lagoon-ui/issues/258