### PR TITLE
change: add branches and pullrequests during org project creation

### DIFF
--- a/cypress/e2e/organizations/overview.cy.ts
+++ b/cypress/e2e/organizations/overview.cy.ts
@@ -23,7 +23,7 @@ describe('Organization overview page', () => {
     overview.doQuotaFieldCheck();
   });
 
-  it.only('Changes org friendly name/description', () => {
+  it('Changes org friendly name/description', () => {
     registerIdleHandler('idle');
 
     overview.changeOrgFriendlyname(testData.organizations.overview.friendlyName);

--- a/cypress/e2e/rbac/developer.cy.ts
+++ b/cypress/e2e/rbac/developer.cy.ts
@@ -114,7 +114,7 @@ describe('DEVELOPER permission test suites', () => {
       environmentOverview.doDeleteEnvironmentError('main');
     });
 
-    it('Deletes stating environment', () => {
+    it('Deletes staging environment', () => {
       cy.visit(`${Cypress.env('url')}/projects/lagoon-demo/lagoon-demo-staging`);
 
       cy.intercept('POST', Cypress.env('api'), req => {
@@ -147,7 +147,7 @@ describe('DEVELOPER permission test suites', () => {
     });
 
     it('Fails to cancel any deployment - no permission to CANCEL for DEVELOPER', () => {
-      cy.visit(`${Cypress.env('url')}/projects/lagoon-demo/lagoon-demo-staging/deployments`);
+      cy.visit(`${Cypress.env('url')}/projects/lagoon-demo/lagoon-demo-main/deployments`);
 
       registerIdleHandler('idle');
 

--- a/cypress/e2e/rbac/guest.cy.ts
+++ b/cypress/e2e/rbac/guest.cy.ts
@@ -146,7 +146,7 @@ describe('GUEST permission test suites', () => {
     });
 
     it('Fails to do cancel a deployment - no permission for GUEST', () => {
-      cy.visit(`${Cypress.env('url')}/projects/lagoon-demo/lagoon-demo-staging/deployments`);
+      cy.visit(`${Cypress.env('url')}/projects/lagoon-demo/lagoon-demo-main/deployments`);
       registerIdleHandler('idle');
 
       cy.intercept('POST', Cypress.env('api'), req => {

--- a/cypress/e2e/rbac/maintainer.cy.ts
+++ b/cypress/e2e/rbac/maintainer.cy.ts
@@ -136,7 +136,7 @@ describe('MAINTAINER permission test suites', () => {
       environmentOverview.doDeleteEnvironmentError('main');
     });
 
-    it('Deletes stating environment', () => {
+    it('Deletes staging environment', () => {
       cy.visit(`${Cypress.env('url')}/projects/lagoon-demo/lagoon-demo-staging`);
 
       cy.intercept('POST', Cypress.env('api'), req => {
@@ -169,7 +169,7 @@ describe('MAINTAINER permission test suites', () => {
     });
 
     it('Cancels a staging deployment', () => {
-      cy.visit(`${Cypress.env('url')}/projects/lagoon-demo/lagoon-demo-staging/deployments`);
+      cy.visit(`${Cypress.env('url')}/projects/lagoon-demo/lagoon-demo-main/deployments`);
 
       registerIdleHandler('idle');
 

--- a/cypress/e2e/rbac/reporter.cy.ts
+++ b/cypress/e2e/rbac/reporter.cy.ts
@@ -143,7 +143,7 @@ describe('REPORTER permission test suites', () => {
     });
 
     it('Fails to do cancel a deployment - no permission for REPORTER', () => {
-      cy.visit(`${Cypress.env('url')}/projects/lagoon-demo/lagoon-demo-staging/deployments`);
+      cy.visit(`${Cypress.env('url')}/projects/lagoon-demo/lagoon-demo-main/deployments`);
 
       registerIdleHandler('idle');
 
@@ -168,6 +168,8 @@ describe('REPORTER permission test suites', () => {
       cy.waitForNetworkIdle('@idle', 500);
 
       deployment.navigateToRunningDeployment();
+
+      cy.waitForNetworkIdle('@idle', 500);
       deployment.doFailedCancelDeployment();
     });
   });

--- a/cypress/support/actions/deployment/DeploymentAction.ts
+++ b/cypress/support/actions/deployment/DeploymentAction.ts
@@ -33,7 +33,6 @@ export default class deploymentAction {
   }
 
   doFailedCancelDeployment() {
-    
     deployment.getCancelDeploymentBtn().click();
 
     cy.wait('@gqlcancelDeploymentMutation');

--- a/cypress/support/actions/deployment/DeploymentAction.ts
+++ b/cypress/support/actions/deployment/DeploymentAction.ts
@@ -33,6 +33,7 @@ export default class deploymentAction {
   }
 
   doFailedCancelDeployment() {
+    
     deployment.getCancelDeploymentBtn().click();
 
     cy.wait('@gqlcancelDeploymentMutation');

--- a/cypress/support/actions/organizations/ProjectsActions.ts
+++ b/cypress/support/actions/organizations/ProjectsActions.ts
@@ -17,7 +17,7 @@ export default class ProjectsActions {
 
     projects.selectTarget();
 
-    projects.getAddConfirm().click();
+    projects.getAddConfirm().click({ force: true });
 
     cy.wait('@gqladdProjectToOrganizationMutation');
 
@@ -32,7 +32,7 @@ export default class ProjectsActions {
 
     projects.selectTarget();
 
-    projects.getAddConfirm().click();
+    projects.getAddConfirm().click({ force: true });
 
     cy.wait('@gqladdProjectToOrganizationMutation').then(interception => {
       expect(interception.response?.statusCode).to.eq(200);

--- a/src/components/Organizations/NewProject/StyledNewProject.tsx
+++ b/src/components/Organizations/NewProject/StyledNewProject.tsx
@@ -20,6 +20,9 @@ export const StyledNewProject = styled.div`
 
   .form-box {
     margin-bottom: 1rem;
+    &.spacetop {
+      margin-top: 1rem;
+    }
   }
 
   .docs-link {

--- a/src/components/Organizations/NewProject/index.js
+++ b/src/components/Organizations/NewProject/index.js
@@ -182,7 +182,24 @@ const OrgNewProject = ({
 
                     <div className="form-box spacetop">
                       <label>
-                        Branches
+                        Branches{' '}
+                        <Tooltip
+                          overlayClassName="orgTooltip lg"
+                          title={
+                            <>
+                              <p> Which Pull Requests should be deployed, can be one of::</p>
+                              <p> - true - all branches are deployed </p>
+                              <p>- false - no branches are deployed</p>
+                              <p>
+                                - regex of all branches that can be deployed (including production), example:
+                                '^(main|staging)$'
+                              </p>
+                            </>
+                          }
+                          placement="right"
+                        >
+                          <InfoCircleOutlined style={{ fontSize: '1rem' }} />
+                        </Tooltip>
                         <input
                           type="text"
                           placeholder="Branches"
@@ -194,7 +211,21 @@ const OrgNewProject = ({
 
                     <div className="form-box">
                       <label>
-                        Pull requests
+                        Pull requests{' '}
+                        <Tooltip
+                          overlayClassName="orgTooltip lg"
+                          title={
+                            <>
+                              <p> Which branches should be deployed, can be one of:</p>
+                              <p> - true - all pull requests are deployed </p>
+                              <p> - false - no pull requests are deployed</p>
+                              <p>- regex of all Pull Request titles that can be deployed, example: '[BUILD]'</p>
+                            </>
+                          }
+                          placement="right"
+                        >
+                          <InfoCircleOutlined style={{ fontSize: '1rem' }} />
+                        </Tooltip>
                         <input
                           placeholder="Pull requests"
                           type="text"

--- a/src/components/Organizations/NewProject/index.js
+++ b/src/components/Organizations/NewProject/index.js
@@ -72,6 +72,9 @@ const OrgNewProject = ({
   refresh,
 }) => {
   const [addUserToProject, setAddUserToProject] = React.useState(true);
+  const [pullRequests, setPullRequests] = React.useState(true);
+  const [branches, setBranches] = React.useState(true);
+
   return (
     <StyledNotificationWrapper>
       <div className="margins">
@@ -182,6 +185,25 @@ const OrgNewProject = ({
                       />
                       <span>Add my user to this project</span>
                     </Checkbox>
+
+                    <Checkbox>
+                      <input
+                        type="checkbox"
+                        checked={branches}
+                        onChange={({ target: { checked } }) => setBranches(checked)}
+                      />
+                      <span>Branches</span>
+                    </Checkbox>
+
+                    <Checkbox>
+                      <input
+                        type="checkbox"
+                        checked={pullRequests}
+                        onChange={({ target: { checked } }) => setPullRequests(checked)}
+                      />
+                      <span>Pull requests</span>
+                    </Checkbox>
+
                     <div className="docs-link">
                       <div className="info-icon">
                         <Image src={info} alt="" />
@@ -219,7 +241,7 @@ const OrgNewProject = ({
                             inputGitURL.indexOf(' ') > 0 ||
                             inputProdEnv === '' ||
                             inputProdEnv.indexOf(' ') > 0 ||
-                            selectedDeployTarget === undefined
+                            selectedDeployTarget == undefined
                           }
                           action={() => {
                             addGroupProject({
@@ -230,6 +252,8 @@ const OrgNewProject = ({
                                 productionEnvironment: inputProdEnv,
                                 organization: parseInt(organizationId, 10),
                                 addOrgOwner: addUserToProject,
+                                pullrequests: String(pullRequests),
+                                branches: String(branches),
                               },
                             });
                           }}

--- a/src/components/Organizations/NewProject/index.js
+++ b/src/components/Organizations/NewProject/index.js
@@ -72,8 +72,8 @@ const OrgNewProject = ({
   refresh,
 }) => {
   const [addUserToProject, setAddUserToProject] = React.useState(true);
-  const [pullRequests, setPullRequests] = React.useState(true);
-  const [branches, setBranches] = React.useState(true);
+  const [pullRequests, setPullRequests] = React.useState('');
+  const [branches, setBranches] = React.useState('');
 
   return (
     <StyledNotificationWrapper>
@@ -98,6 +98,8 @@ const OrgNewProject = ({
                   setProjectName({ target: { value: '' } });
                   setGitURL({ target: { value: '' } });
                   setProdEnv({ target: { value: '' } });
+                  setPullRequests('');
+                  setBranches('');
                   setSelectedDeployTarget({ target: { value: '' } });
                   closeModal();
                 });
@@ -177,6 +179,31 @@ const OrgNewProject = ({
                         />
                       </RoleSelect>
                     </label>
+
+                    <div className="form-box spacetop">
+                      <label>
+                        Branches
+                        <input
+                          type="text"
+                          placeholder="Branches"
+                          value={branches}
+                          onChange={({ target: { value } }) => setBranches(value)}
+                        />
+                      </label>
+                    </div>
+
+                    <div className="form-box">
+                      <label>
+                        Pull requests
+                        <input
+                          placeholder="Pull requests"
+                          type="text"
+                          value={pullRequests}
+                          onChange={({ target: { value } }) => setPullRequests(value)}
+                        />
+                      </label>
+                    </div>
+
                     <Checkbox>
                       <input
                         type="checkbox"
@@ -184,24 +211,6 @@ const OrgNewProject = ({
                         onChange={({ target: { checked } }) => setAddUserToProject(checked)}
                       />
                       <span>Add my user to this project</span>
-                    </Checkbox>
-
-                    <Checkbox>
-                      <input
-                        type="checkbox"
-                        checked={branches}
-                        onChange={({ target: { checked } }) => setBranches(checked)}
-                      />
-                      <span>Branches</span>
-                    </Checkbox>
-
-                    <Checkbox>
-                      <input
-                        type="checkbox"
-                        checked={pullRequests}
-                        onChange={({ target: { checked } }) => setPullRequests(checked)}
-                      />
-                      <span>Pull requests</span>
                     </Checkbox>
 
                     <div className="docs-link">
@@ -252,8 +261,8 @@ const OrgNewProject = ({
                                 productionEnvironment: inputProdEnv,
                                 organization: parseInt(organizationId, 10),
                                 addOrgOwner: addUserToProject,
-                                pullrequests: String(pullRequests),
-                                branches: String(branches),
+                                ...(pullRequests ? { pullRequests } : {}),
+                                ...(branches ? { branches } : {}),
                               },
                             });
                           }}

--- a/src/components/Organizations/NewProject/index.js
+++ b/src/components/Organizations/NewProject/index.js
@@ -187,13 +187,18 @@ const OrgNewProject = ({
                           overlayClassName="orgTooltip lg"
                           title={
                             <>
-                              <p> Which Pull Requests should be deployed, can be one of::</p>
-                              <p> - true - all branches are deployed </p>
-                              <p>- false - no branches are deployed</p>
-                              <p>
+                              <b>[Default: true]</b>
+                              <br />
+                              <span> Which Pull Requests should be deployed, can be one of:</span>
+                              <br />
+                              <span> - true - all branches are deployed </span>
+                              <br />
+                              <span>- false - no branches are deployed</span>
+                              <br />
+                              <span>
                                 - regex of all branches that can be deployed (including production), example:
                                 '^(main|staging)$'
-                              </p>
+                              </span>
                             </>
                           }
                           placement="right"
@@ -216,10 +221,15 @@ const OrgNewProject = ({
                           overlayClassName="orgTooltip lg"
                           title={
                             <>
-                              <p> Which branches should be deployed, can be one of:</p>
-                              <p> - true - all pull requests are deployed </p>
-                              <p> - false - no pull requests are deployed</p>
-                              <p>- regex of all Pull Request titles that can be deployed, example: '[BUILD]'</p>
+                              <b>[Default: true]</b>
+                              <br />
+                              <span> Which branches should be deployed, can be one of:</span>
+                              <br />
+                              <span> - true - all pull requests are deployed </span>
+                              <br />
+                              <span> - false - no pull requests are deployed</span>
+                              <br />
+                              <span>- regex of all Pull Request titles that can be deployed, example: '[BUILD]'</span>
                             </>
                           }
                           placement="right"

--- a/src/components/Organizations/NewProject/index.js
+++ b/src/components/Organizations/NewProject/index.js
@@ -190,15 +190,16 @@ const OrgNewProject = ({
                               <b>[Default: true]</b>
                               <br />
                               <span> Which branches should be deployed, can be one of:</span>
-                              <br />
-                              <span> - true - all branches are deployed </span>
-                              <br />
-                              <span>- false - no branches are deployed</span>
-                              <br />
-                              <span>
-                                - regex of all branches that can be deployed (including production), example:
-                                '^(main|staging)$'
-                              </span>
+                              <ul className="tooltiplist">
+                                <li>true - all branches are deployed </li>
+
+                                <li>false - no branches are deployed</li>
+
+                                <li>
+                                  regex of all branches that can be deployed (including production), example:
+                                  '^(main|staging)$'
+                                </li>
+                              </ul>
                             </>
                           }
                           placement="right"
@@ -224,12 +225,13 @@ const OrgNewProject = ({
                               <b>[Default: true]</b>
                               <br />
                               <span> Which pull requests should be deployed, can be one of:</span>
-                              <br />
-                              <span> - true - all pull requests are deployed </span>
-                              <br />
-                              <span> - false - no pull requests are deployed</span>
-                              <br />
-                              <span>- regex of all Pull Request titles that can be deployed, example: '[BUILD]'</span>
+                              <ul className="tooltiplist">
+                                <li>true - all pull requests are deployed </li>
+
+                                <li>false - no pull requests are deployed</li>
+
+                                <li>regex of all Pull Request titles that can be deployed, example: '[BUILD]'</li>
+                              </ul>
                             </>
                           }
                           placement="right"

--- a/src/components/Organizations/NewProject/index.js
+++ b/src/components/Organizations/NewProject/index.js
@@ -189,7 +189,7 @@ const OrgNewProject = ({
                             <>
                               <b>[Default: true]</b>
                               <br />
-                              <span> Which Pull Requests should be deployed, can be one of:</span>
+                              <span> Which branches should be deployed, can be one of:</span>
                               <br />
                               <span> - true - all branches are deployed </span>
                               <br />
@@ -223,7 +223,7 @@ const OrgNewProject = ({
                             <>
                               <b>[Default: true]</b>
                               <br />
-                              <span> Which branches should be deployed, can be one of:</span>
+                              <span> Which pull requests should be deployed, can be one of:</span>
                               <br />
                               <span> - true - all pull requests are deployed </span>
                               <br />

--- a/src/layouts/GlobalStyles/index.tsx
+++ b/src/layouts/GlobalStyles/index.tsx
@@ -42,6 +42,12 @@ body {
   color: ${props => (props.theme.colorScheme === 'dark' ? '#000' : '#fff')};
   background: ${props => (props.theme.colorScheme === 'dark' ? '#fff' : '#000')};
   }
+  &.lg{
+      .ant-tooltip-content{
+        width:max-content;
+      }
+
+  }
 }
 .componentTooltip {
   .ant-tooltip-arrow:before{

--- a/src/layouts/GlobalStyles/index.tsx
+++ b/src/layouts/GlobalStyles/index.tsx
@@ -41,6 +41,15 @@ body {
   .ant-tooltip-content .ant-tooltip-inner{
   color: ${props => (props.theme.colorScheme === 'dark' ? '#000' : '#fff')};
   background: ${props => (props.theme.colorScheme === 'dark' ? '#fff' : '#000')};
+
+  .tooltiplist{
+    margin-left: 0.812rem;
+    li{
+      margin-bottom: initial;
+      padding-left: 0;
+      list-style: disc;
+    }
+  }
   }
   &.lg{
       .ant-tooltip-content{


### PR DESCRIPTION
will close #267 
<img width="626" alt="Screenshot 2024-07-01 at 01 26 10" src="https://github.com/uselagoon/lagoon-ui/assets/76407236/85f841eb-1c05-47a3-a736-4e3ab635b424">

@shreddedbacon if `branches` and `pullrequests` aren't provided they're set to true, but the api doesn't allow non-string values, so currently this PR sends values as stringified values. seems wrong