### PR TITLE
chore: set network-timeout on yarn install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Node builder image
-FROM uselagoon/node-20-builder:latest as builder
+FROM uselagoon/node-20-builder:latest AS builder
 
 COPY . /app/
 
@@ -25,7 +25,7 @@ ARG GRAPHQL_API
 ENV GRAPHQL_API=$GRAPHQL_API
 
 # Build app
-RUN yarn run build
+RUN yarn --network-timeout 300000 run build
 
 EXPOSE 3000
 CMD ["yarn", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM uselagoon/node-20-builder:latest AS builder
 
 COPY . /app/
 
-RUN yarn install
+RUN yarn install --network-timeout 300000
 
 
 # Node service image
@@ -25,7 +25,7 @@ ARG GRAPHQL_API
 ENV GRAPHQL_API=$GRAPHQL_API
 
 # Build app
-RUN yarn --network-timeout 300000 run build
+RUN yarn run build
 
 EXPOSE 3000
 CMD ["yarn", "start"]

--- a/cypress/cypress.config.ts
+++ b/cypress/cypress.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'cypress';
 
 export default defineConfig({
   requestTimeout: 15000,
+  defaultCommandTimeout: 8000,
   e2e: {
     env: {
       api: 'http://0.0.0.0:33000/graphql',

--- a/test/docker-compose.yaml
+++ b/test/docker-compose.yaml
@@ -28,6 +28,12 @@ services:
         condition: service_completed_successfully # don't start the lagoon migrations until the db migrations is completed
       keycloak:
         condition: service_started
+  api-sidecar-handler:
+    # this is neded for the internal dns references
+    container_name: apisidecarhandler
+    image: testlagoon/api-sidecar-handler:main
+    ports:
+      - '3333:3333'
   api:
     image: testlagoon/api:main
     ports:
@@ -44,8 +50,14 @@ services:
       - S3_BAAS_ACCESS_KEY_ID=minio
       - S3_BAAS_SECRET_ACCESS_KEY=minio123
       - CONSOLE_LOGGING_LEVEL=trace
+      - SIDECAR_HANDLER_HOST=apisidecarhandler
     depends_on:
-      - api-lagoon-migrations
+      api-lagoon-migrations:
+        condition: service_started
+      keycloak:
+        condition: service_started
+      api-sidecar-handler:
+        condition: service_started
   api-redis:
     image: testlagoon/api-redis:main
   keycloak:

--- a/test/keycloak/configure-keycloak.sh
+++ b/test/keycloak/configure-keycloak.sh
@@ -10,7 +10,7 @@ function is_keycloak_running {
 function configure_user_passwords {
 
   LAGOON_DEMO_USERS=("guest@example.com" "reporter@example.com" "developer@example.com" "maintainer@example.com" "owner@example.com")
-  LAGOON_DEMO_ORG_USERS=("orguser@example.com" "orgviewer@example.com" "orgowner@example.com" "platformowner@example.com")
+  LAGOON_DEMO_ORG_USERS=("orguser@example.com" "orgviewer@example.com" "orgadmin@example.com" "orgowner@example.com" "platformowner@example.com")
 
   for i in ${LAGOON_DEMO_USERS[@]}
   do


### PR DESCRIPTION
This PR adds an extended network-timeout on yarn install to cover the slow arm64 builders