### PR TITLE
Fix: Fixes SSHKey modal

### DIFF
--- a/cypress/support/actions/settings/SettingsAction.ts
+++ b/cypress/support/actions/settings/SettingsAction.ts
@@ -17,7 +17,10 @@ export default class SettingAction {
   }
 
   deleteSshKey(name: string) {
-    settings.getDeleteBtn().should('be.visible').click({ force: true, multiple: true });
+    settings.getDeleteBtn().click();
+    cy.log('enter the  name and confirm');
+    cy.getBySel('confirm-input').type(name);
+    cy.getBySel('deleteConfirm').click();
     cy.contains(name).should('not.exist');
   }
 }

--- a/cypress/support/actions/settings/SettingsAction.ts
+++ b/cypress/support/actions/settings/SettingsAction.ts
@@ -17,7 +17,7 @@ export default class SettingAction {
   }
 
   deleteSshKey(name: string) {
-    settings.getDeleteBtn().click();
+    settings.getDeleteBtn(name);
     cy.log('enter the  name and confirm');
     cy.getBySel('confirm-input').type(name);
     cy.getBySel('deleteConfirm').click();

--- a/cypress/support/repositories/settings/SettingsRepository.ts
+++ b/cypress/support/repositories/settings/SettingsRepository.ts
@@ -10,7 +10,16 @@ export default class SettingsRepository {
   getSubmitBtn() {
     return cy.getBySel('sshKey').parent().next();
   }
-  getDeleteBtn() {
-    return cy.getBySel('deleteKey').getBySel('delete');
+
+  getKeyToDelete() {
+    return cy.getBySel('data-row');
+  }
+  getDeleteBtn(name: string) {
+    this.getKeyToDelete()
+      .contains(name)
+      .parent()
+      .within(() => {
+        cy.getBySel('deleteKey').getBySel('delete').click();
+      });
   }
 }

--- a/cypress/support/repositories/settings/SettingsRepository.ts
+++ b/cypress/support/repositories/settings/SettingsRepository.ts
@@ -11,6 +11,6 @@ export default class SettingsRepository {
     return cy.getBySel('sshKey').parent().next();
   }
   getDeleteBtn() {
-    return cy.getBySel('deleteKey').getBySel('deleteBtn');
+    return cy.getBySel('deleteKey').getBySel('delete');
   }
 }

--- a/src/components/DeleteConfirm/index.js
+++ b/src/components/DeleteConfirm/index.js
@@ -11,6 +11,7 @@ import { color } from 'lib/variables';
 export const DeleteConfirm = ({
   deleteType,
   deleteName,
+  deleteMessage,
   icon,
   onDelete,
   inputValue,
@@ -28,11 +29,15 @@ export const DeleteConfirm = ({
       </Button>
       <Modal isOpen={open} onRequestClose={closeModal} contentLabel={`Confirm delete ${deleteType}`}>
         <React.Fragment>
-          <p>
-            This will delete all resources associated with the {deleteType}{' '}
-            <span className="delete-name">{deleteName}</span> and cannot be undone. Make sure this is something you
-            really want to do!
-          </p>
+          {deleteMessage ? (
+            <p>{deleteMessage}</p>
+          ) : (
+            <p>
+              This will delete all resources associated with the {deleteType}{' '}
+              <span className="delete-name">{deleteName}</span> and cannot be undone. Make sure this is something you
+              really want to do!
+            </p>
+          )}
           <p>Type the name of the {deleteType} to confirm.</p>
           <div className="form-input">
             <input type="text" value={inputValue} onChange={setInputValue} data-cy="confirm-input" />

--- a/src/components/DeleteConfirm/index.stories.tsx
+++ b/src/components/DeleteConfirm/index.stories.tsx
@@ -45,6 +45,7 @@ export const WithConfirmationBlocked = ({
     icon={<DeleteOutlined />}
     deleteType="environment"
     deleteName="Forty-two"
+    deleteMessage
     onDelete={onDeleteFunction}
     inputValue=""
     setInputValue={setInputValueFunction}

--- a/src/components/SshKeys/index.js
+++ b/src/components/SshKeys/index.js
@@ -69,7 +69,7 @@ const SshKeys = ({ me: { id, email, sshKeys: keys }, loading, handleRefetch }) =
 
           {keys &&
             keys.map(key => (
-              <div className="data-row" key={key.id}>
+              <div className="data-row" key={key.id} data-cy="data-row">
                 <div className="name">
                   {key.id} - {key.name}
                 </div>

--- a/src/components/SshKeys/index.js
+++ b/src/components/SshKeys/index.js
@@ -190,7 +190,6 @@ const SshKeys = ({ me: { id, email, sshKeys: keys }, loading, handleRefetch }) =
                             deleteType="SSH Key"
                             deleteMessage={deleteMessage}
                             deleteName={key.name}
-                            testId="deleteBtn"
                             loading={called}
                             variant="red"
                             onDelete={() =>

--- a/src/layouts/GlobalStyles/index.tsx
+++ b/src/layouts/GlobalStyles/index.tsx
@@ -68,13 +68,18 @@ body {
   }
 }
 .ant-modal .ant-modal-content{
-  background: ${props => (props.theme.colorScheme === 'dark' ? '#eaeaea' : '#fff')};
+  background:${props => props.theme.backgrounds.primary};;
   .ant-modal-header{
     border-radius: 0;
     background-color: transparent;
+    
+    .ant-modal-title{
+      color: ${props => props.theme.texts.primary};
+    }
   }
   .ant-modal-body {
     margin-block: 1rem;
+    color: ${props => props.theme.texts.primary};
     > * {
       margin-bottom: 0.5rem;
     }

--- a/src/lib/query/Me.js
+++ b/src/lib/query/Me.js
@@ -11,6 +11,7 @@ export default gql`
         id
         name
         keyType
+        keyValue
         created
         keyFingerprint
       }


### PR DESCRIPTION
Fixes global styling on the antd modal to allow dark mode to work properly & populates the existing key in the modal. Also adds an error notification instead of rendering a div with the error message, adds a delete confirmation & updates relevant tests.


![image](https://github.com/user-attachments/assets/9fc1dab6-0a17-423d-804e-28e89843c268)

closes https://github.com/uselagoon/lagoon-ui/issues/289
