### PR TITLE
tests: Modify Cypress error attribute checks

### DIFF
--- a/cypress/e2e/rbac/developer.cy.ts
+++ b/cypress/e2e/rbac/developer.cy.ts
@@ -85,7 +85,7 @@ describe('DEVELOPER permission test suites', () => {
       cy.wait('@gqladdEnvVariableMutation').then(interception => {
         expect(interception.response?.statusCode).to.eq(200);
 
-        const errorMessage = 'Unauthorized: You don\'t have permission to "project:add" on "env_var": {"project":18}';
+        const errorMessage = 'Unauthorized: You don\'t have permission to "project:add" on "env_var"';
         expect(interception.response?.body).to.have.property('errors');
 
         cy.wrap(interception.response?.body.errors[0]).should('deep.include', { message: errorMessage });

--- a/cypress/e2e/rbac/guest.cy.ts
+++ b/cypress/e2e/rbac/guest.cy.ts
@@ -181,8 +181,7 @@ describe('GUEST permission test suites', () => {
 
       cy.waitForNetworkIdle('@idle', 500);
 
-      const errMessage =
-        'Error: GraphQL error: Unauthorized: You don\'t have permission to "view" on "backup"';
+      const errMessage = 'Error: GraphQL error: Unauthorized: You don\'t have permission to "view" on "backup"';
 
       cy.get('main').should('exist').find('p').should('exist').and('have.text', errMessage);
     });

--- a/cypress/e2e/rbac/guest.cy.ts
+++ b/cypress/e2e/rbac/guest.cy.ts
@@ -85,7 +85,7 @@ describe('GUEST permission test suites', () => {
       cy.wait('@gqladdEnvVariableMutation').then(interception => {
         expect(interception.response?.statusCode).to.eq(200);
 
-        const errorMessage = 'Unauthorized: You don\'t have permission to "project:add" on "env_var": {"project":18}';
+        const errorMessage = 'Unauthorized: You don\'t have permission to "project:add" on "env_var"';
         expect(interception.response?.body).to.have.property('errors');
 
         cy.wrap(interception.response?.body.errors[0]).should('deep.include', { message: errorMessage });
@@ -182,7 +182,7 @@ describe('GUEST permission test suites', () => {
       cy.waitForNetworkIdle('@idle', 500);
 
       const errMessage =
-        'Error: GraphQL error: Unauthorized: You don\'t have permission to "view" on "backup": {"project":18}';
+        'Error: GraphQL error: Unauthorized: You don\'t have permission to "view" on "backup"';
 
       cy.get('main').should('exist').find('p').should('exist').and('have.text', errMessage);
     });

--- a/cypress/e2e/rbac/organizations/orgViewer.cy.ts
+++ b/cypress/e2e/rbac/organizations/orgViewer.cy.ts
@@ -103,7 +103,7 @@ describe(`Organizations ORGVIEWER journey`, () => {
 
     cy.wait('@gqladdProjectToGroupMutation').then(interception => {
       expect(interception.response?.statusCode).to.eq(200);
-      const errorMessage = `Unauthorized: You don't have permission to "addGroup" on "organization": {"organization":1}`;
+      const errorMessage = `Unauthorized: You don't have permission to "addGroup" on "organization"`;
       expect(interception.response?.body).to.have.property('errors');
 
       cy.wrap(interception.response?.body.errors[0]).should('deep.include', { message: errorMessage });
@@ -121,7 +121,7 @@ describe(`Organizations ORGVIEWER journey`, () => {
 
     cy.wait('@gqladdNotificationToProjectMutation').then(interception => {
       expect(interception.response?.statusCode).to.eq(200);
-      const errorMessage = `Unauthorized: You don't have permission to "addNotification" on "organization": {"organization":1}`;
+      const errorMessage = `Unauthorized: You don't have permission to "addNotification" on "organization"`;
 
       expect(interception.response?.body).to.have.property('errors');
 

--- a/cypress/e2e/rbac/reporter.cy.ts
+++ b/cypress/e2e/rbac/reporter.cy.ts
@@ -181,8 +181,7 @@ describe('REPORTER permission test suites', () => {
 
       cy.waitForNetworkIdle('@idle', 500);
 
-      const errMessage =
-        'Error: GraphQL error: Unauthorized: You don\'t have permission to "view" on "backup"';
+      const errMessage = 'Error: GraphQL error: Unauthorized: You don\'t have permission to "view" on "backup"';
 
       cy.get('main').should('exist').find('p').should('exist').and('have.text', errMessage);
     });

--- a/cypress/e2e/rbac/reporter.cy.ts
+++ b/cypress/e2e/rbac/reporter.cy.ts
@@ -82,7 +82,7 @@ describe('REPORTER permission test suites', () => {
       cy.wait('@gqladdEnvVariableMutation').then(interception => {
         expect(interception.response?.statusCode).to.eq(200);
 
-        const errorMessage = 'Unauthorized: You don\'t have permission to "project:add" on "env_var": {"project":18}';
+        const errorMessage = 'Unauthorized: You don\'t have permission to "project:add" on "env_var"';
         expect(interception.response?.body).to.have.property('errors');
 
         cy.wrap(interception.response?.body.errors[0]).should('deep.include', { message: errorMessage });
@@ -182,7 +182,7 @@ describe('REPORTER permission test suites', () => {
       cy.waitForNetworkIdle('@idle', 500);
 
       const errMessage =
-        'Error: GraphQL error: Unauthorized: You don\'t have permission to "view" on "backup": {"project":18}';
+        'Error: GraphQL error: Unauthorized: You don\'t have permission to "view" on "backup"';
 
       cy.get('main').should('exist').find('p').should('exist').and('have.text', errMessage);
     });

--- a/cypress/support/actions/envOverview/EnvOverviewAction.ts
+++ b/cypress/support/actions/envOverview/EnvOverviewAction.ts
@@ -47,7 +47,7 @@ export default class EnvOverviewAction {
 
     const errorMessage = `Unauthorized: You don\'t have permission to "delete:${
       branch === 'main' ? 'production' : 'development'
-    }" on "environment": {"project":18}`;
+    }" on "environment"`;
 
     cy.wait('@gqldeleteEnvironmentMutation').then(interception => {
       expect(interception.response?.statusCode).to.eq(200);

--- a/cypress/support/actions/organizations/GroupsAction.ts
+++ b/cypress/support/actions/organizations/GroupsAction.ts
@@ -31,7 +31,7 @@ export default class GroupAction {
     cy.wait('@gqladdGroupToOrganizationMutation').then(interception => {
       expect(interception.response?.statusCode).to.eq(200);
 
-      const errorMessage = `Unauthorized: You don't have permission to "addGroup" on "organization": {"organization":1}`;
+      const errorMessage = `Unauthorized: You don't have permission to "addGroup" on "organization"`;
       expect(interception.response?.body).to.have.property('errors');
 
       cy.wrap(interception.response?.body.errors[0]).should('deep.include', { message: errorMessage });

--- a/cypress/support/actions/organizations/NotificationsAction.ts
+++ b/cypress/support/actions/organizations/NotificationsAction.ts
@@ -89,7 +89,7 @@ export default class NotificationsAction {
     cy.wait(`@gqladdNotification${getMutationName(notifType)}Mutation`).then(interception => {
       expect(interception.response?.statusCode).to.eq(200);
 
-      const errorMessage = `Unauthorized: You don't have permission to "addNotification" on "organization": {"organization":1}`;
+      const errorMessage = `Unauthorized: You don't have permission to "addNotification" on "organization"`;
 
       expect(interception.response?.body).to.have.property('errors');
 

--- a/cypress/support/actions/organizations/OverviewAction.ts
+++ b/cypress/support/actions/organizations/OverviewAction.ts
@@ -60,7 +60,7 @@ export default class OverviewAction {
     cy.wait('@gqlupdateOrganizationFriendlyNameMutation').then(interception => {
       expect(interception.response?.statusCode).to.eq(200);
 
-      const errorMessage = 'Unauthorized: You don\'t have permission to "updateOrganization" on "organization": 1';
+      const errorMessage = 'Unauthorized: You don\'t have permission to "updateOrganization" on "organization"';
       expect(interception.response?.body).to.have.property('errors');
 
       cy.wrap(interception.response?.body.errors[0]).should('deep.include', { message: errorMessage });
@@ -92,7 +92,7 @@ export default class OverviewAction {
     cy.wait('@gqlupdateOrganizationFriendlyNameMutation').then(interception => {
       expect(interception.response?.statusCode).to.eq(200);
 
-      const errorMessage = 'Unauthorized: You don\'t have permission to "updateOrganization" on "organization": 1';
+      const errorMessage = 'Unauthorized: You don\'t have permission to "updateOrganization" on "organization"';
       expect(interception.response?.body).to.have.property('errors');
 
       cy.wrap(interception.response?.body.errors[0]).should('deep.include', { message: errorMessage });

--- a/cypress/support/actions/organizations/ProjectsActions.ts
+++ b/cypress/support/actions/organizations/ProjectsActions.ts
@@ -37,7 +37,7 @@ export default class ProjectsActions {
     cy.wait('@gqladdProjectToOrganizationMutation').then(interception => {
       expect(interception.response?.statusCode).to.eq(200);
 
-      const errorMessage = `Unauthorized: You don't have permission to "addProject" on "organization": {"organization":1}`;
+      const errorMessage = `Unauthorized: You don't have permission to "addProject" on "organization"`;
       expect(interception.response?.body).to.have.property('errors');
 
       cy.wrap(interception.response?.body.errors[0]).should('deep.include', { message: errorMessage });

--- a/cypress/support/actions/project/ProjectAction.ts
+++ b/cypress/support/actions/project/ProjectAction.ts
@@ -58,7 +58,7 @@ export default class ProjectAction {
       .should('exist')
       .should(
         'include.text',
-        'GraphQL error: Unauthorized: You don\'t have permission to "deploy:development" on "environment": {"project":18}'
+        'GraphQL error: Unauthorized: You don\'t have permission to "deploy:development" on "environment"'
       );
   }
 }

--- a/cypress/support/actions/tasks/TasksAction.ts
+++ b/cypress/support/actions/tasks/TasksAction.ts
@@ -35,8 +35,7 @@ export default class TasksAction {
     cy.wait('@gqltaskDrushSqlDumpMutation').then(interception => {
       expect(interception.response?.statusCode).to.eq(200);
 
-      const errorMessage =
-        'Unauthorized: You don\'t have permission to "drushSqlDump:production" on "task"';
+      const errorMessage = 'Unauthorized: You don\'t have permission to "drushSqlDump:production" on "task"';
       expect(interception.response?.body).to.have.property('errors');
 
       cy.wrap(interception.response?.body.errors[0]).should('deep.include', { message: errorMessage });
@@ -56,8 +55,7 @@ export default class TasksAction {
     cy.wait('@gqltaskDrushArchiveDumpMutation').then(interception => {
       expect(interception.response?.statusCode).to.eq(200);
 
-      const errorMessage =
-        'Unauthorized: You don\'t have permission to "drushArchiveDump:production" on "task"';
+      const errorMessage = 'Unauthorized: You don\'t have permission to "drushArchiveDump:production" on "task"';
       expect(interception.response?.body).to.have.property('errors');
 
       cy.wrap(interception.response?.body.errors[0]).should('deep.include', { message: errorMessage });
@@ -77,8 +75,7 @@ export default class TasksAction {
     cy.wait('@gqltaskDrushUserLoginMutation').then(interception => {
       expect(interception.response?.statusCode).to.eq(200);
 
-      const errorMessage =
-        'Unauthorized: You don\'t have permission to "drushUserLogin:production" on "task"';
+      const errorMessage = 'Unauthorized: You don\'t have permission to "drushUserLogin:production" on "task"';
       expect(interception.response?.body).to.have.property('errors');
 
       cy.wrap(interception.response?.body.errors[0]).should('deep.include', { message: errorMessage });

--- a/cypress/support/actions/tasks/TasksAction.ts
+++ b/cypress/support/actions/tasks/TasksAction.ts
@@ -36,7 +36,7 @@ export default class TasksAction {
       expect(interception.response?.statusCode).to.eq(200);
 
       const errorMessage =
-        'Unauthorized: You don\'t have permission to "drushSqlDump:production" on "task": {"project":18}';
+        'Unauthorized: You don\'t have permission to "drushSqlDump:production" on "task"';
       expect(interception.response?.body).to.have.property('errors');
 
       cy.wrap(interception.response?.body.errors[0]).should('deep.include', { message: errorMessage });
@@ -57,7 +57,7 @@ export default class TasksAction {
       expect(interception.response?.statusCode).to.eq(200);
 
       const errorMessage =
-        'Unauthorized: You don\'t have permission to "drushArchiveDump:production" on "task": {"project":18}';
+        'Unauthorized: You don\'t have permission to "drushArchiveDump:production" on "task"';
       expect(interception.response?.body).to.have.property('errors');
 
       cy.wrap(interception.response?.body.errors[0]).should('deep.include', { message: errorMessage });
@@ -78,7 +78,7 @@ export default class TasksAction {
       expect(interception.response?.statusCode).to.eq(200);
 
       const errorMessage =
-        'Unauthorized: You don\'t have permission to "drushUserLogin:production" on "task": {"project":18}';
+        'Unauthorized: You don\'t have permission to "drushUserLogin:production" on "task"';
       expect(interception.response?.body).to.have.property('errors');
 
       cy.wrap(interception.response?.body.errors[0]).should('deep.include', { message: errorMessage });
@@ -106,7 +106,7 @@ export default class TasksAction {
     cy.wait('@gqlcancelTaskMutation').then(interception => {
       expect(interception.response?.statusCode).to.eq(200);
 
-      const errorMessage = 'Unauthorized: You don\'t have permission to "cancel:production" on "task": {"project":18}';
+      const errorMessage = 'Unauthorized: You don\'t have permission to "cancel:production" on "task"';
       expect(interception.response?.body).to.have.property('errors');
 
       cy.wrap(interception.response?.body.errors[0]).should('deep.include', { message: errorMessage });

--- a/test/docker-compose.yaml
+++ b/test/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3.2'
-
 name: lagoon-minimal
 
 services:
@@ -41,12 +39,12 @@ services:
     networks:
       - default
     environment:
-      - KEYCLOAK_URL=http://172.17.0.1:38088
+      - KEYCLOAK_FRONTEND_URL=http://172.17.0.1:38088
       - NODE_ENV=development
       - OPENSEARCH_INTEGRATION_ENABLED=false
       - DISABLE_CORE_HARBOR=true
       - CI=${CI:-true}
-      - S3_FILES_HOST=http://0.0.0.0:39000
+      - S3_FILES_HOST=http://172.17.0.1:39000
       - S3_BAAS_ACCESS_KEY_ID=minio
       - S3_BAAS_SECRET_ACCESS_KEY=minio123
       - CONSOLE_LOGGING_LEVEL=trace

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,6 @@
     "skipLibCheck": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
-    "suppressImplicitAnyIndexErrors": true,
     "ignoreDeprecations": "5.0",
     "noEmit": true,
     "incremental": true,


### PR DESCRIPTION
The recent change in Lagoon https://github.com/uselagoon/lagoon/pull/3736 removed attributes from error messages.

This PR removes the explicit check for these attributes from the Cypress response checks.
It also fixes the KEYCLOAK variable references to match the latest changes in main.