### PR TITLE
chore: pin typescript to 5.6.2

### DIFF
--- a/.github/workflows/ui-workflow.yaml
+++ b/.github/workflows/ui-workflow.yaml
@@ -34,7 +34,7 @@ jobs:
 
     - name: Linting
       run: |
-        yarn add typescript
+        yarn add typescript@5.6.2
         yarn lint
 
   cypress-tests:

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "sass": "^1.63.4",
     "storybook": "^7.6.7",
     "storybook-addon-designs": "^7.0.0-beta.2",
-    "typescript": "^5.0.4"
+    "typescript": "5.6.2"
   },
   "resolutions": {
     "jackspeak": "2.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15135,7 +15135,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@^5.0.4:
+typescript@5.6.2:
   version "5.6.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.6.2.tgz#d1de67b6bef77c41823f822df8f0b3bcff60a5a0"
   integrity sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==


### PR DESCRIPTION
Circumvents temporarily

```
src/components/Projects/index.stories.tsx(21,5): error TS2322: Type 'Project[]' is not assignable to type 'never[]'.
  Type 'Project' is not assignable to type 'never'. 
  ```