### PR TITLE
tests: rework some Cypress waits - save screenshots and logs

### DIFF
--- a/.github/workflows/ui-workflow.yaml
+++ b/.github/workflows/ui-workflow.yaml
@@ -111,6 +111,20 @@ jobs:
         cypress_keycloak: http://localhost:8088/auth
         cypress_url: http://localhost:3003
 
+    - uses: actions/upload-artifact@v4
+      # add the line below to store screenshots only on failures
+      if: failure()
+      with:
+        name: cypress-screenshots
+        path: cypress/screenshots
+        if-no-files-found: ignore # 'warn' or 'error' are also available, defaults to `warn`
+    - uses: actions/upload-artifact@v4
+      if: failure()
+      with:
+        name: cypress-videos
+        path: cypress/videos
+        if-no-files-found: ignore # 'warn' or 'error' are also available, defaults to `warn`
+
     - name: Stop Docker containers
       run: |
         make development-api-down

--- a/.github/workflows/ui-workflow.yaml
+++ b/.github/workflows/ui-workflow.yaml
@@ -111,14 +111,22 @@ jobs:
         cypress_keycloak: http://localhost:8088/auth
         cypress_url: http://localhost:3003
 
-    - uses: actions/upload-artifact@v4
+
+    - name: Export API logs on failure
+      if: failure()
+      run: |
+        docker compose -p core-lagoon-ui logs api
+
+    - name: Save screenshots on failure
+      uses: actions/upload-artifact@v4
       # add the line below to store screenshots only on failures
       if: failure()
       with:
         name: cypress-screenshots
         path: cypress/screenshots
         if-no-files-found: ignore # 'warn' or 'error' are also available, defaults to `warn`
-    - uses: actions/upload-artifact@v4
+    - name: Save videos on failure
+      uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: cypress-videos

--- a/cypress/e2e/general/variables.cy.ts
+++ b/cypress/e2e/general/variables.cy.ts
@@ -31,9 +31,7 @@ describe('Project variables page', () => {
     cy.waitForNetworkIdle('@idle', 500);
     environment.doAddVariable(name, value);
 
-    cy.intercept('POST', Cypress.env('api')).as('addRequest');
-
-    cy.wait('@addRequest');
+    cy.waitForNetworkIdle('@idle', 1000);
 
     cy.log('check if variable was created');
     cy.get('.data-table > .data-row').should('contain', name);
@@ -56,9 +54,7 @@ describe('Project variables page', () => {
 
     environment.doDeleteVariable(name);
 
-    cy.intercept('POST', Cypress.env('api')).as('deleteRequest');
-
-    cy.wait('@deleteRequest');
+    cy.waitForNetworkIdle('@idle', 1000);
 
     cy.contains('No Project variables set').should('exist');
   });

--- a/cypress/e2e/organizations/users.cy.ts
+++ b/cypress/e2e/organizations/users.cy.ts
@@ -35,8 +35,8 @@ describe('Org Users page', () => {
   });
 
   after(() => {
-    registerIdleHandler('groupQuery');
     cy.visit(`${Cypress.env('url')}/organizations/lagoon-demo-organization/groups`);
+    registerIdleHandler('groupQuery');
     group.doDeleteGroup(testData.organizations.groups.newGroupName);
     group.doDeleteGroup(testData.organizations.groups.newGroupName2);
   });


### PR DESCRIPTION
A weird nonsense bug that has suddenly appeared as an order of operations glitch - making sure the IdleHandler registers after the page change seems to resolve it :crossed_fingers: 