### PR TITLE
fix: add buildstep to deployment subscription

### DIFF
--- a/src/lib/subscription/Deployments.js
+++ b/src/lib/subscription/Deployments.js
@@ -10,6 +10,7 @@ export default gql`
       started
       completed
       buildLog
+      buildStep
     }
   }
 `;


### PR DESCRIPTION
Add `buildStep` to the deployment subscription so that the build step gets updated.