### PR TITLE
Fix: Removes duplicate map block

### DIFF
--- a/src/components/Task/index.tsx
+++ b/src/components/Task/index.tsx
@@ -69,12 +69,6 @@ const Task: FC<TaskProps> = ({ task, projectId, environmentId }) => {
             <div>
               <label>Files</label>
               <ul className="field">
-                {task.files.map(file => (
-                  <li key={file.id}>
-                    <a href={file.download}>{file.filename}</a>
-                  </li>
-                ))}
-
                 {task.files.map(file => {
                   const { id, filename, download } = file;
                   const downloadURL = isValidUrl(download) ? download : undefined;


### PR DESCRIPTION
Currently task files are duplicated in the `Task` component due to a duplicate map block. This updates the component to remove the errant duplicate block.

![image](https://github.com/user-attachments/assets/8f63160b-6494-45bb-876e-420fe4a51373)
