### PR TITLE
Remove project org link

### DIFF
--- a/src/components/ProjectDetailsSidebar/index.js
+++ b/src/components/ProjectDetailsSidebar/index.js
@@ -119,9 +119,7 @@ const ProjectDetailsSidebar = ({ project }) => {
         <FieldWrapper className="field-wrapper organization">
           <div>
             <label>Organization</label>
-            <div>
-              {project?.organizationDetails.friendlyName || project?.organizationDetails.name}
-            </div>
+            <div>{project?.organizationDetails.friendlyName || project?.organizationDetails.name}</div>
           </div>
         </FieldWrapper>
       )}

--- a/src/components/ProjectDetailsSidebar/index.js
+++ b/src/components/ProjectDetailsSidebar/index.js
@@ -120,14 +120,7 @@ const ProjectDetailsSidebar = ({ project }) => {
           <div>
             <label>Organization</label>
             <div>
-              <OrganizationLink
-                organizationSlug={project.organizationDetails.name}
-                organizationId={project.organizationDetails.id}
-                orgFriendlyName={project.organizationDetails.friendlyName}
-                className="deployLink deployTargets hover-state"
-              >
-                {project.organizationDetails.friendlyName || project.organizationDetails.name}
-              </OrganizationLink>
+              {project?.organizationDetails.friendlyName || project?.organizationDetails.name}
             </div>
           </div>
         </FieldWrapper>


### PR DESCRIPTION
Removes the organization link component on the Project page, leaving only the organization name.

Closes #332