### PR TITLE
Fix: Fixes type error for Organization Users page

### DIFF
--- a/src/components/Organizations/PaginatedTable/PaginatedTable.tsx
+++ b/src/components/Organizations/PaginatedTable/PaginatedTable.tsx
@@ -119,7 +119,7 @@ const PaginatedTable: FC<Props> = ({
 
     if (defaultViewOptions) {
       if (defaultViewOptions.type === 'group') {
-        filtered = filtered.filter(dataItem => dataItem.type !== 'project-default-group');
+        filtered = filtered.filter(dataItem => dataItem.groupType !== 'project-default-group');
       }
       if (defaultViewOptions.type === 'user') {
         filtered = filtered.filter(dataItem => {
@@ -202,7 +202,7 @@ const PaginatedTable: FC<Props> = ({
 
     if (!defaultsSelected) {
       if (defaultViewOptions?.type === 'group') {
-        filtered = filtered.filter(dataItem => dataItem.type !== 'project-default-group');
+        filtered = filtered.filter(dataItem => dataItem.groupType !== 'project-default-group');
       }
       if (defaultViewOptions?.type === 'user') {
         filtered = filtered.filter(dataItem => {
@@ -372,7 +372,7 @@ const PaginatedTable: FC<Props> = ({
 
     if (defaultViewOptions) {
       if (defaultViewOptions?.type === 'group') {
-        count = unfilteredData.filter(dataItem => dataItem.type === 'project-default-group').length;
+        count = unfilteredData.filter(dataItem => dataItem.groupType === 'project-default-group').length;
       }
       if (defaultViewOptions?.type === 'user') {
         count = unfilteredData.filter(dataItem => {

--- a/src/lib/query/organizations/UserByEmailAndOrganization.js
+++ b/src/lib/query/organizations/UserByEmailAndOrganization.js
@@ -8,6 +8,7 @@ export default gql`
         id
         name
         role
+        groupType
       }
     }
   }

--- a/src/pages/organizations/user.js
+++ b/src/pages/organizations/user.js
@@ -90,19 +90,6 @@ export const PageUser = ({ router }) => {
     return <OrganizationNotFound variables={{ name: router.query.organizationSlug }} />;
   }
 
-  const orgGroups = organization.organization.groups;
-  const userGroupRoles = user?.userByEmailAndOrganization?.groupRoles;
-
-  orgGroups.length &&
-    Array.isArray(userGroupRoles) &&
-    userGroupRoles.forEach((groupRole, idx, selfArr) => {
-      const found = orgGroups.find(group => {
-        return group.id == groupRole.id;
-      });
-
-      if (found) selfArr[idx].type = found.type;
-    });
-
   return (
     <>
       <Head>


### PR DESCRIPTION
The current logic attempts to add the `type` to the immutable gql results - causing the current type error. This removes the immutable logic entirely and simply requests the `groupType` in the gql request rather than trying to mutate the response data.

closes #338