### PR TITLE
Change: Handles internal_container_registry scope deprecation

### DIFF
--- a/src/components/AddVariable/StyledAddVariable.tsx
+++ b/src/components/AddVariable/StyledAddVariable.tsx
@@ -27,6 +27,24 @@ export const NewVariableModal = styled.div`
   .var-modal {
     padding: 10px 0;
   }
+  .warning-container {
+    border: 1px solid ${props => props.theme.texts.primary};
+    padding: 1rem;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin: 4px auto;
+    border-radius: 5px;
+  }
+  .warning-icon {
+    width: 20px;
+    height: 20px;
+    color: ${props => props.theme.texts.primary};
+  }
+  .warning-text {
+    color: ${props => props.theme.texts.primary};
+    margin: 0 auto;
+  }
   .variable-target {
     text-align: center;
     color: #5f6f7a;

--- a/src/components/AddVariable/StyledAddVariable.tsx
+++ b/src/components/AddVariable/StyledAddVariable.tsx
@@ -27,24 +27,6 @@ export const NewVariableModal = styled.div`
   .var-modal {
     padding: 10px 0;
   }
-  .warning-container {
-    border: 1px solid ${props => props.theme.texts.primary};
-    padding: 1rem;
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    margin: 4px auto;
-    border-radius: 5px;
-  }
-  .warning-icon {
-    width: 20px;
-    height: 20px;
-    color: ${props => props.theme.texts.primary};
-  }
-  .warning-text {
-    color: ${props => props.theme.texts.primary};
-    margin: 0 auto;
-  }
   .variable-target {
     text-align: center;
     color: #5f6f7a;

--- a/src/components/AddVariable/index.js
+++ b/src/components/AddVariable/index.js
@@ -213,17 +213,14 @@ export const AddVariable = ({
               onChange={varValue ? handleUpdateValue : setInputValue}
             ></textarea>
           </div>
-            {inputScope === "INTERNAL_CONTAINER_REGISTRY" || updateScope === "INTERNAL_CONTAINER_REGISTRY" ? (
-              <div className="var-modal warning-container">
-                <div className="warning-icon">
-                  <WarningOutlined width="50px" />
-                </div>
-                <p className="warning-text">
-                  INTERNAL_CONTAINER_REGISTRY scope is deprecated & can no longer be set.
-                </p>
+          {inputScope === 'INTERNAL_CONTAINER_REGISTRY' || updateScope === 'INTERNAL_CONTAINER_REGISTRY' ? (
+            <div className="var-modal warning-container">
+              <div className="warning-icon">
+                <WarningOutlined width="50px" />
               </div>
-              ) : null
-            }
+              <p className="warning-text">INTERNAL_CONTAINER_REGISTRY scope is deprecated & can no longer be set.</p>
+            </div>
+          ) : null}
           <div className="form-input add-var-btn" data-cy="add-variable">
             <a href="#" className="hover-state" onClick={handleCloseModal}>
               cancel

--- a/src/components/AddVariable/index.js
+++ b/src/components/AddVariable/index.js
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import ButtonBootstrap from 'react-bootstrap/Button';
 import ReactSelect from 'react-select';
 
-import { LoadingOutlined } from '@ant-design/icons';
+import { LoadingOutlined, WarningOutlined } from '@ant-design/icons';
 import { useMutation } from '@apollo/client';
 import { Popconfirm } from 'antd';
 import withLogic from 'components/AddVariable/logic';
@@ -23,7 +23,7 @@ const scopeOptions = [
   { value: 'CONTAINER_REGISTRY', label: 'CONTAINER_REGISTRY' },
   {
     value: 'INTERNAL_CONTAINER_REGISTRY',
-    label: 'INTERNAL_CONTAINER_REGISTRY',
+    label: 'INTERNAL_CONTAINER_REGISTRY - Deprecated',
   },
 ];
 
@@ -213,6 +213,17 @@ export const AddVariable = ({
               onChange={varValue ? handleUpdateValue : setInputValue}
             ></textarea>
           </div>
+            {inputScope === "INTERNAL_CONTAINER_REGISTRY" || updateScope === "INTERNAL_CONTAINER_REGISTRY" ? (
+              <div className="var-modal warning-container">
+                <div className="warning-icon">
+                  <WarningOutlined width="50px" />
+                </div>
+                <p className="warning-text">
+                  INTERNAL_CONTAINER_REGISTRY scope is deprecated & can no longer be set.
+                </p>
+              </div>
+              ) : null
+            }
           <div className="form-input add-var-btn" data-cy="add-variable">
             <a href="#" className="hover-state" onClick={handleCloseModal}>
               cancel

--- a/src/components/AddVariable/index.js
+++ b/src/components/AddVariable/index.js
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import ButtonBootstrap from 'react-bootstrap/Button';
 import ReactSelect from 'react-select';
 
-import { LoadingOutlined, WarningOutlined } from '@ant-design/icons';
+import { LoadingOutlined } from '@ant-design/icons';
 import { useMutation } from '@apollo/client';
 import { Popconfirm } from 'antd';
 import withLogic from 'components/AddVariable/logic';
@@ -21,10 +21,6 @@ const scopeOptions = [
   { value: 'RUNTIME', label: 'RUNTIME' },
   { value: 'GLOBAL', label: 'GLOBAL' },
   { value: 'CONTAINER_REGISTRY', label: 'CONTAINER_REGISTRY' },
-  {
-    value: 'INTERNAL_CONTAINER_REGISTRY',
-    label: 'INTERNAL_CONTAINER_REGISTRY - Deprecated',
-  },
 ];
 
 export const AddVariable = ({
@@ -213,14 +209,6 @@ export const AddVariable = ({
               onChange={varValue ? handleUpdateValue : setInputValue}
             ></textarea>
           </div>
-          {inputScope === 'INTERNAL_CONTAINER_REGISTRY' || updateScope === 'INTERNAL_CONTAINER_REGISTRY' ? (
-            <div className="var-modal warning-container">
-              <div className="warning-icon">
-                <WarningOutlined width="50px" />
-              </div>
-              <p className="warning-text">INTERNAL_CONTAINER_REGISTRY scope is deprecated & can no longer be set.</p>
-            </div>
-          ) : null}
           <div className="form-input add-var-btn" data-cy="add-variable">
             <a href="#" className="hover-state" onClick={handleCloseModal}>
               cancel


### PR DESCRIPTION
Flags deprecation on scope in dropdown, & adds warning if selected.

<img width="544" height="536" alt="image" src="https://github.com/user-attachments/assets/62dd8f2c-b813-4daa-93f2-e1a155569a75" />

Requires https://github.com/uselagoon/lagoon/pull/3973

Edit: Image is out of date, no longer shows scope